### PR TITLE
Adding info about Truffle and Ganache

### DIFF
--- a/dev-tools.asciidoc
+++ b/dev-tools.asciidoc
@@ -6,11 +6,11 @@ Frameworks can be used to ease development. By doing everything yourself you get
 
 === Truffle
 
-Github link; http://github.com/trufflesuite/truffle
+Github link; https://github.com/trufflesuite/truffle
 
 Website link; https://truffleframework.com
 
-Documentation link; http://truffleframework.com/docs
+Documentation link; https://truffleframework.com/docs
 
 npm packages repository link; https://www.npmjs.com/package/truffle
 

--- a/dev-tools.asciidoc
+++ b/dev-tools.asciidoc
@@ -6,6 +6,14 @@ Frameworks can be used to ease development. By doing everything yourself you get
 
 === Truffle
 
+Github link; http://github.com/trufflesuite/truffle
+
+Website link; https://truffleframework.com
+
+Documentation link; http://truffleframework.com/docs
+
+npm packages repository link; https://www.npmjs.com/package/truffle
+
 === Embark
 
 Github link; https://github.com/iurimatias/embark-framework
@@ -26,68 +34,19 @@ Read the docs link; http://zeppelin-solidity.readthedocs.io/en/latest/index.html
 
 == Utilities
 
-=== ethereumJS testrpc: A rapid development test blockchain and RPC server
+=== Ganache: A personal blockchain for Ethereum development
 
-https://github.com/ethereumjs/testrpc
+You can use Ganache to deploy contracts, develop your applications, and run tests. It is available as a desktop application for Windows, Mac, and Linux.
 
+Website: http://truffleframework.com/ganache
 
-npm install -g ethereumjs-testrpc
+=== Ganache CLI: Ganache as a command-line tool
 
--a or --accounts: Specify the number of accounts to generate at startup.
--b or --blocktime: Specify blocktime in seconds for automatic mining. Default is 0 and no auto-mining.
--d or --deterministic: Generate deterministic addresses based on a pre-defined mnemonic.
--n or --secure: Lock available accounts by default (good for third party transaction signing)
--m or --mnemonic: Use a specific HD wallet mnemonic to generate initial addresses.
--p or --port: Port number to listen on. Defaults to 8545.
--h or --hostname: Hostname to listen on. Defaults to Node's server.listen() default.
--s or --seed: Use arbitrary data to generate the HD wallet mnemonic to be used.
--g or --gasPrice: Use a custom Gas Price (defaults to 20000000000)
--l or --gasLimit: Use a custom Gas Limit (defaults to 0x47E7C4)
--f or --fork: Fork from another currently running Ethereum client at a given block. Input should be the HTTP location and port of the other client, e.g. http://localhost:8545. You can optionally specify the block to fork from using an @ sign: http://localhost:8545@1599200.
--i or --network-id: Specify the network id the TestRPC will use to identify itself (defaults to the current time or the network id of the forked blockchain if configured)
---db: Specify a path to a directory to save the chain database. If a database already exists, the TestRPC will initialize that chain instead of creating a new one.
---debug: Output VM opcodes for debugging
---mem: Output TestRPC memory usage statistics. This replaces normal output.
+This tool was previously known under the name "ethereumJS TestRPC".
 
-----
-$ testrpc
-EthereumJS TestRPC v4.1.1 (ganache-core: 1.1.2)
+https://github.com/trufflesuite/ganache-cli/
 
-Available Accounts
-==================
-(0) 0x778ae5fa9d8c8a384a593363cef0becb2d070921
-(1) 0x91f1dd068764ee3cbe85bd0d659aa72aafb34a15
-(2) 0x393ac2db68f5f8316e4cb2be50795df10ff231d1
-(3) 0x07e3d99a88442422dace37146e28d80d34bb14e8
-(4) 0x4c6e573ffa0cfedef4f902b4a047fff2454ec015
-(5) 0x2c1cc6465e8b44eafa7b14e8617268907e4eac92
-(6) 0xf6e69bce0412dfa4bee1a9a8f77efbb3571a73cf
-(7) 0xd07a3956a3b02743dd4776992fb9682e725b3a0c
-(8) 0x176c56282d4b45175697b88ca69f20a61376d0a9
-(9) 0x3562f562d24d3bebb5ae1f8b273c1d947fc13a25
-
-Private Keys
-==================
-(0) 0d98c9a1ae5e77221fe9df0f0e84a3ba577d3b2404b35e66858632200eb73590
-(1) 8a02896f01fa0e1ba32ef7a08ee5e714b016affba39ba10f55d65a41e1ced4d0
-(2) 6f358cf8f7a6711fc4a28aca572f086e49f2f6c6fc6c293b8ca392616cc6ee81
-(3) abd76126a51af43af5b1ceb4b7dffeb57faca031ced23a3acb0d9f0735b79942
-(4) 87a9f3dd6ed0f8a7f5ea4ab09c7bb12d2ebfb41d34aa2e0a6b2fc07b75ab3653
-(5) 5db730fafbce064a6933d9feabacd872b1d197c6f3124e6dedd9a87f787dc52c
-(6) b27b8690c349ca17300feba311f5407d066d56d8d3c290fd944ebee183ec4e48
-(7) 2a3de6a7bce44347e14a8855a3e204d32f4a942b694889fad53afb99decc9fad
-(8) a8420478fce10715a28f64e77e56edf96b26255e367dae488e4d6e492e5bbbed
-(9) 25bd9f40961eac6e83b0b789dd9c63d727f8db9aeabea4eed7339c97da7ec824
-
-HD Wallet
-==================
-Mnemonic:      size air tattoo execute control crawl dumb impulse bulk cart oblige wolf
-Base HD Path:  m/44'/60'/0'/0/{account_index}
-
-Listening on localhost:8545
-
-----
-
+npm install -g ganache-cli
 
 === ethereumJS helpeth: A command line utility
 


### PR DESCRIPTION
Hi there! We noticed that you were adding a reference section that included Truffle. (Our collective ears were burning.) We figured we'd help out with this PR.

Also, the TestRPC has been renamed and moved. It is now no longer under the auspices of the EthereumJS, but brought under the Truffle Suite and now known as Ganache. Ganache actually has two flavors (a desktop app, and the more familiar terminal application, which is known as ganache-cli). You can read more about this change [on our blog](http://truffleframework.com/blog/testrpc-is-now-ganache).

If you have any questions, or would like more information, we'd be happy to supply. Excited for your book!

Thanks,
Mike (from the Truffle team)