### PR TITLE
hashlib sha3_256 monkey patch activation for sys.version_info < (3, 6) - previous PR correction

### DIFF
--- a/code/jupyter_notebook/keys_and_addresses_python_notebook.ipynb
+++ b/code/jupyter_notebook/keys_and_addresses_python_notebook.ipynb
@@ -24,12 +24,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Import libraries\n",
     "\n",
+    "import sys\n",
     "\n",
     "# Vitalik Buterin's Python Library for Bitcoin\n",
     "# No longer maintained!\n",
@@ -39,6 +40,12 @@
     "# Vitalik Buterin's Python Library for Ethereum\n",
     "# https://github.com/ethereum/pyethereum\n",
     "import ethereum\n",
+    "\n",
+    "# pysha3 package - SHA-3 (Keccak) for Python 2.7 - 3.5\n",
+    "# The sha3 module monkey patches the hashlib module.\n",
+    "# The monkey patch is automatically activated with the first import of the sha3 module.\n",
+    "if sys.version_info < (3, 6):\n",
+    "    import sha3\n",
     "\n",
     "# Wrong source of SHA3 (FIPS-202 not Keccak-256)\n",
     "from hashlib import sha3_256 as hashlib_sha3\n",
@@ -55,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -110,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -139,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -148,7 +155,7 @@
        "0"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -164,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -199,7 +206,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -217,7 +224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -235,18 +242,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'address_hash' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-12-0bbc4340ad5c>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0maddress_hash_hex\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mencode_hex\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkeccak256\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0maddress\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 5\u001b[0;31m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0maddress_hash\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m: name 'address_hash' is not defined"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "23a69c1653e4ebbb619b0b2cb8a9bad49892a8b9695d9a19d8f673ca991deae1\n"
      ]
     }
    ],
@@ -260,9 +263,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EIP-55 encoded Ethereum Address: 0x001d3F1ef827552Ae1114027BD3ECF1f086bA0F9\n"
+     ]
+    }
+   ],
    "source": [
     "# Simple implementation of EIP-55\n",
     "# For every alphabetic character of the address, \n",
@@ -304,7 +315,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
For **sys.version_info** < (3, 6)

```
In [1]: from hashlib import sha3_256 as hashlib_sha3
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-6b319b7e2950> in <module>()
----> 1 from hashlib import sha3_256 as hashlib_sha3

ImportError: cannot import name 'sha3_256'
```

**pysha3**: SHA-3 (Keccak) for Python 2.7 - 3.5
SHA-3 wrapper (keccak) for Python. The package is a wrapper around the optimized Keccak Code Package,

The sha3 module monkey patches the hashlib module . The monkey patch is automatically activated with the first import of the sha3 module.