### PR TITLE
added testnet faucets

### DIFF
--- a/ethereum-testnets.asciidoc
+++ b/ethereum-testnets.asciidoc
@@ -8,6 +8,31 @@
 
 === Getting test-ETH - Testnet Faucets
 
+Since testnets do not operate with real money, the incentive to secure the testnets by miners is low.
+Therefore, the testnets must be differently protected against abuse and attacks.
+As a result, so-called faucets exist, which distribute free test ether to developers in a controlled manner.
+
+==== Ropsten
+
+For the Ropsten testnet, different faucets exist:
+
+* http://faucet.ropsten.be:3001/
+This faucet provides the possibility to queue the address that should receive the test ether.
+
+* Metamask
+Metamask offers an option to buy ether.
+If the Ropsten testnet is used, this buy option will allow selecting the Ropsten Test Faucet Service.
+
+==== Rinkeby
+
+The Rinkeby faucet is located at https://faucet.rinkeby.io/.
+To request test ether it is necessary to make a public post on either Twitter, Goole Plus or Facebook.
+
+==== Kovan
+
+The Kovan testnet supports various methods to request test ether.
+Further information can be found in the Kovan testnet GitHub Repository located at https://github.com/kovan-testnet/faucet/blob/master/README.md.
+
 === History of Ethereum Testnets
 
 https://www.ethnews.com/ropsten-to-kovan-to-rinkeby-ethereums-testnet-troubles

--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -138,3 +138,4 @@ Many contributors offered comments, corrections, and additions to the early-rele
 Following is a list of notable GitHub contributors, including their GitHub ID in parentheses:
 
 * Jane Example (JaneExampleGitHubID)
+* Christopher Gondek (christophergondek)


### PR DESCRIPTION
I added some information about test ether faucets. I reasoned why there are faucets and which faucets exist. This list of faucets can, however, never be complete as there may be many different private faucets. I guess we can only link to the most prominent ones.
