### PR TITLE
intro.asciidoc - Added a point to private key tips

### DIFF
--- a/intro.asciidoc
+++ b/intro.asciidoc
@@ -16,6 +16,8 @@ With that control comes a big responsibility. If you lose your keys, you lose ac
 
 * Do not send money to any of the addresses shown in this book. The private keys are listed in the book and someone will immediately take that money.
 
+* Make a second "savings" wallet to store the majority of your funds. Only use it to send funds to your "spending wallet". This will help keep your savings private, as it is easy for a reciever of Ether to determine the amount Ether in the wallet of the sender.
+
 [[ether_units]]
 === Ether currency units
 


### PR DESCRIPTION
It's an important security requirement for a receiver of Ether not to know when the sender has a large amount of Ether (they may become a hacking target). Hence a "savings" wallet is recommended.