### PR TITLE
Fixed list numbering continuation over code block.

### DIFF
--- a/keys-addresses.asciidoc
+++ b/keys-addresses.asciidoc
@@ -475,7 +475,8 @@ Keccak-256("001d3f1ef827552ae1114027bd3ecf1f086ba0f9")
 23a69c1653e4ebbb619b0b2cb8a9bad49892a8b9695d9a19d8f673ca991deae1
 ----
 
-2. Capitalize each alphabetic address character if the corresponding hex digit of the hash is greater than or equal to +0x8+. This is easier to show if we line up the address and the hash:
+[start=2]
+1. Capitalize each alphabetic address character if the corresponding hex digit of the hash is greater than or equal to +0x8+. This is easier to show if we line up the address and the hash:
 
 ----
 Address: 001d3f1ef827552ae1114027bd3ecf1f086ba0f9


### PR DESCRIPTION
Asciidoc list numbering got confused by the code block. Needs manual setting of the list number.