### PR TITLE
Typo corrections

### DIFF
--- a/clients.asciidoc
+++ b/clients.asciidoc
@@ -69,7 +69,7 @@ Advantages:
 
 Disadvantages:
 * No other users means that it doesn't behave the same as a public blockchain. There's no competition for transaction space or sequencing of transactions.
-* No miners other than you means that mining is more predictable, therefore you can't test some scenarios that occur on a public blockchains
+* No miners other than you means that mining is more predictable, therefore you can't test some scenarios that occur on a public blockchain
 * No other contracts means you have to deploy everything that you want to test, including dependencies and contract libraries
 * You can't recreate some of the public contracts and their addresses to test some scenarios (eg. the DAO contract)
 

--- a/clients.asciidoc
+++ b/clients.asciidoc
@@ -71,7 +71,7 @@ Disadvantages:
 * No other users means that it doesn't behave the same as a public blockchain. There's no competition for transaction space or sequencing of transactions.
 * No miners other than you means that mining is more predictable, therefore you can't test some scenarios that occur on a public blockchain
 * No other contracts means you have to deploy everything that you want to test, including dependencies and contract libraries
-* You can't recreate some of the public contracts and their addresses to test some scenarios (eg. the DAO contract)
+* You can't recreate some of the public contracts and their addresses to test some scenarios (e.g. the DAO contract)
 
 [[requirements]]
 == Hardware Requirements for a Full Node

--- a/clients.asciidoc
+++ b/clients.asciidoc
@@ -233,7 +233,7 @@ Don't start running +geth+ yet, because it will start synchronizing the blockcha
 
 == Parity
 
-Parity is an implementation of a full node Ethreum client and dapp browser. Parity was written from the "ground up" in Rust, a systems programming language with the aim of building a highly modular, very secure and scalable Ethereum client. Parity is developed by Parity Tech, a UK company and is released under a GPLv3 open source license.
+Parity is an implementation of a full node Ethereum client and dapp browser. Parity was written from the "ground up" in Rust, a systems programming language with the aim of building a highly modular, very secure and scalable Ethereum client. Parity is developed by Parity Tech, a UK company and is released under a GPLv3 open source license.
 
 [NOTE]
 ====

--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -158,3 +158,4 @@ Following is a list of notable GitHub contributors, including their GitHub ID in
 * Steve Klise (sklise)
 * Jonathan Velando (rigzba21)
 * Pierre-Jean Subervie (pjsub)
+* Martin Berger (drmartinberger)

--- a/tokens.asciidoc
+++ b/tokens.asciidoc
@@ -98,9 +98,9 @@ Approval event:: Event logged upon successful call to +approve+.
 
 ===== ERC20 optional functions
 
-name:: Returns a human readable name (eg. "US Dollars") of the token.
+name:: Returns a human readable name (e.g. "US Dollars") of the token.
 
-symbol:: Returns a human readable symbol (eg. "USD") for the token.
+symbol:: Returns a human readable symbol (e.g. "USD") for the token.
 
 decimals:: Returns the number of decimals used to divide token amounts. For example, if decimals is 2, then the token amount is divided by 100 to get its user representation.
 


### PR DESCRIPTION
* singular instead of plural usage
* consistent usage of e.g.
* Ethereum instead of Ethreum