### PR TITLE
Deleted typo (comma not needed)

### DIFF
--- a/tokens.asciidoc
+++ b/tokens.asciidoc
@@ -158,7 +158,7 @@ contract ERC20 {
 
 If you examine any ERC20 implementation, it will contain two data structures, one to track balances and one to track allowances. In Solidity, they are implemented with a _data mapping_.
 
-The first data mapping implements an internal table of token balances, by owner. This allows the token contract to keep track of who owns the tokens. Each transfer, is a deduction from one balance and an addition to another balance.
+The first data mapping implements an internal table of token balances, by owner. This allows the token contract to keep track of who owns the tokens. Each transfer is a deduction from one balance and an addition to another balance.
 
 .Balances: a mapping from address (owner) to amount (balance)
 ----


### PR DESCRIPTION
Was: Each transfer, is a deduction from one balance and an addition to another balance.
Now: Each transfer is a deduction from one balance and an addition to another balance.