### PR TITLE
Minor corrections

### DIFF
--- a/clients.asciidoc
+++ b/clients.asciidoc
@@ -53,12 +53,12 @@ Advantages:
 
 * A Ropsten node needs to sync and store much less data, about 10GB.
 * A Ropsten node can sync fully in a few hours.
-* To deploy contracts or make transactions you need test-ETH, which has no value and can be acquired for free from several sources.
+* To deploy contracts or make transactions you need test ether, which has no value and can be acquired for free from several sources.
 * Ropsten is a public blockchain with many other users and contracts, running "live".
 
 Disadvantages:
 
-* You can't use "real" money on Ropsten, it runs on test-ETH.
+* You can't use "real" money on Ropsten, it runs on test ether.
 * Consequently, you can't test security against real adversaries, as there is nothing at stake.
 * There are some aspects of a public blockchain that you cannot test realistically on Ropsten. For example, transaction fees are not a consideration on testnet.
 
@@ -69,7 +69,7 @@ For many testing purposes, the best option is to launch a single instance privat
 Advantages:
 
 * No syncing and almost no data on disk. You mine the first block yourself.
-* No need to find test-ETH, you "award" yourself mining rewards that you can use for testing.
+* No need to find test ether, you "award" yourself mining rewards that you can use for testing.
 * No other users, just you.
 * No other contracts, just the ones you deploy after you launch it.
 

--- a/dev-tools.asciidoc
+++ b/dev-tools.asciidoc
@@ -268,7 +268,7 @@ truffle(localnode)> web3.eth.accounts
   '0xdb5dc1a13e3a55cf3b4587cd8d1e5fdeb6738145' ]
 ----
 
-Our parity client has two wallets, with some test-ETH on Ropsten. The +web3.eth.accounts+ attribute contains a list of all the accounts. We can check the balance of the first account, using the +getBalance+ function:
+Our parity client has two wallets, with some test ether on Ropsten. The +web3.eth.accounts+ attribute contains a list of all the accounts. We can check the balance of the first account, using the +getBalance+ function:
 
 ----
 truffle(localnode)> web3.eth.getBalance(web3.eth.accounts[0]).toNumber()
@@ -286,7 +286,7 @@ truffle(localnode)> web3.eth.getBalance(Faucet.address).toNumber()
 truffle(localnode)>
 ----
 
-Next, we'll use +sendTransaction+ to send some test-ETH to fund the +Faucet+. Note the use of +web3.toWei+ to convert ether units for us. Typing eighteen zeros without making a mistake is both difficult and dangerous, so it's always better to use a unit converter for values. Here's how we send the transaction:
+Next, we'll use +sendTransaction+ to send some test ether to fund the +Faucet+. Note the use of +web3.toWei+ to convert ether units for us. Typing eighteen zeros without making a mistake is both difficult and dangerous, so it's always better to use a unit converter for values. Here's how we send the transaction:
 
 ----
 truffle(localnode)> web3.eth.sendTransaction({from:web3.eth.accounts[0], to:Faucet.address, value:web3.toWei(0.5, 'ether')});
@@ -300,7 +300,7 @@ truffle(localnode)> web3.eth.getBalance(Faucet.address).toNumber()
 500000000000000000
 ----
 
-Let's call the +withdraw+ function now, to withdraw some test-ETH from the Faucet:
+Let's call the +withdraw+ function now, to withdraw some test ether from the Faucet:
 
 ----
 truffle(localnode)> Faucet.deployed().then(instance => {instance.withdraw(web3.toWei(0.1, 'ether'))}).then(console.log)

--- a/ethereum-testnets.asciidoc
+++ b/ethereum-testnets.asciidoc
@@ -8,7 +8,7 @@
 
 === Network Provider Infura
 
-=== Getting test-ETH - Testnet Faucets
+=== Getting test ether - Testnet Faucets
 
 Since testnets do not operate with real money, the incentive to secure the testnets by miners is low.
 Therefore, the testnets must be differently protected against abuse and attacks.

--- a/intro.asciidoc
+++ b/intro.asciidoc
@@ -158,7 +158,7 @@ image::images/metamask_ropsten_faucet.png["MetaMask Ropsten Test Faucet"]
 
 You may notice that the web page already contains your MetaMask wallet's Ethereum address. MetaMask integrates Ethereum enabled web pages (see <<dapps>>) with your MetaMask wallet. MetaMask can "see" Ethereum addresses on the web page, allowing you, for example, to send a payment to an online shop displaying an Ethereum address. MetaMask can also populate the web page with your own wallet's address as a recipient address if the web page requests it. In this page, the faucet application is asking MetaMask for a wallet address to send test-ether to.
 
-Press the green "request 1 ether from faucet" button. You will see a transaction ID appear in the lower part of the page. The faucet app has created transaction - a payment to you. The transaction ID looks like this:
+Press the green "request 1 ether from faucet" button. You will see a transaction ID appear in the lower part of the page. The faucet app has created a transaction - a payment to you. The transaction ID looks like this:
 
 ----
 0x7c7ad5aaea6474adccf6f5c5d6abed11b70a350fbc6f9590109e099568090c57

--- a/intro.asciidoc
+++ b/intro.asciidoc
@@ -156,7 +156,7 @@ Switch MetaMask to the _Ropsten Test Network_. Then click "Buy", and click "Rops
 .MetaMask Ropsten Test Faucet
 image::images/metamask_ropsten_faucet.png["MetaMask Ropsten Test Faucet"]
 
-You may notice that the web page already contains your MetaMask wallet's Ethereum address. MetaMask integrates Ethereum enabled web pages (see <<dapps>>) with your MetaMask wallet. MetaMask can "see" Ethereum addresses on the web page, allowing you, for example, to send a payment to an online shop displaying an Ethereum address. MetaMask can also populate the web page with your own wallet's address as a recipient address if the web page requests it. In this page, the faucet application is asking MetaMask for a wallet address to send test-ether to.
+You may notice that the web page already contains your MetaMask wallet's Ethereum address. MetaMask integrates Ethereum enabled web pages (see <<dapps>>) with your MetaMask wallet. MetaMask can "see" Ethereum addresses on the web page, allowing you, for example, to send a payment to an online shop displaying an Ethereum address. MetaMask can also populate the web page with your own wallet's address as a recipient address if the web page requests it. In this page, the faucet application is asking MetaMask for a wallet address to send test ether to.
 
 Press the green "request 1 ether from faucet" button. You will see a transaction ID appear in the lower part of the page. The faucet app has created a transaction - a payment to you. The transaction ID looks like this:
 
@@ -178,7 +178,7 @@ Try visiting that link, or entering the transaction hash into the +ropsten.ether
 
 === Sending ether from MetaMask
 
-Once we've received our first test ETH from the Ropsten Test Faucet, we will experiment with sending ether, by trying to send some back to the faucet. As you can see on the Ropsten Test Faucet page, there is an option to "donate" 1 ETH to the faucet. This option is available so that once you're done testing, you can return the remainder of your test ether, so that someone else can use it next. Even though test ether has no value, some people hoard it, making it difficult for everyone else to use the test networks. Hoarding test ether is frowned upon!
+Once we've received our first test ether from the Ropsten Test Faucet, we will experiment with sending ether, by trying to send some back to the faucet. As you can see on the Ropsten Test Faucet page, there is an option to "donate" 1 ETH to the faucet. This option is available so that once you're done testing, you can return the remainder of your test ether, so that someone else can use it next. Even though test ether has no value, some people hoard it, making it difficult for everyone else to use the test networks. Hoarding test ether is frowned upon!
 
 Fortunately, we are not test ether hoarders and we want practice sending ether anyway.
 
@@ -243,7 +243,7 @@ In addition to ether, transactions can contain _data_ indicating which specific 
 In the next few sections we will write our first contract. We will then create, fund, and use that contract with our MetaMask wallet and test ether on the Ropsten test network.
 
 [[simple_contract_example]]
-=== A simple contract: a test-ether faucet
+=== A simple contract: a test ether faucet
 
 Ethereum has many different high-level languages, all of which can be used to write a contract and produce EVM bytecode. You can read about many of the most prominent and interesting ones in <<high_level_languages>>. One high-level language is by far the dominant language for smart contract programming: Solidity. Solidity was created by Gavin Wood, the co-author of this book and has become the most widely used language in Ethereum and beyond. We'll use Solidity to write our first contract.
 

--- a/intro.asciidoc
+++ b/intro.asciidoc
@@ -156,7 +156,7 @@ Switch MetaMask to the _Ropsten Test Network_. Then click "Buy", and click "Rops
 .MetaMask Ropsten Test Faucet
 image::images/metamask_ropsten_faucet.png["MetaMask Ropsten Test Faucet"]
 
-You may notice that the web page already contains your MetaMask wallet's Ethereum address. MetaMask integrates Ethereum enabled web pages (see <<dapps>>) with your MetaMask wallet. MetaMask can "see" Ethereum addresses on the web page, allowing you, for example, to send a payment to an online shop displaying an Ethereum address. MetaMask can also populate the web page with your own wallet's address as a recipient address if the web page requests it. In this page, the faucet application is asking MetaMask for a wallet address to send test-ether.
+You may notice that the web page already contains your MetaMask wallet's Ethereum address. MetaMask integrates Ethereum enabled web pages (see <<dapps>>) with your MetaMask wallet. MetaMask can "see" Ethereum addresses on the web page, allowing you, for example, to send a payment to an online shop displaying an Ethereum address. MetaMask can also populate the web page with your own wallet's address as a recipient address if the web page requests it. In this page, the faucet application is asking MetaMask for a wallet address to send test-ether to.
 
 Press the green "request 1 ether from faucet" button. You will see a transaction ID appear in the lower part of the page. The faucet app has created transaction - a payment to you. The transaction ID looks like this:
 


### PR DESCRIPTION
- Completed an incomplete sentence
- Added a missing 'a'
- Consistently use 'test ether' instead of 'test ETH', 'test-ETH' or 'test-ether' 