### PR TITLE
Update clients.asciidoc

### DIFF
--- a/clients.asciidoc
+++ b/clients.asciidoc
@@ -132,7 +132,7 @@ https://www.rustup.rs/
 
 [NOTE]
 ====
-Parity requires Rust version 1.18 or greater.
+Parity requires Rust version 1.24 or greater.
 ====
 
 Parity also requires some software libraries, such as OpenSSL and libudev. To install these on a Linux (Debian) compatible system:
@@ -244,7 +244,7 @@ Parity is an implementation of a full node Ethereum client and dapp browser. Par
 
 [NOTE]
 ====
-Disclosure: The author of this book, Gavin Wood, is the founder of Parity Tech and wrote most of the Parity client. However, the decision to write about Parity was made by the other author, Andreas M. Antonopoulos, because Parity represents 50% of the installed Ethereum client base.
+Disclosure: The author of this book, Gavin Wood, is the founder of Parity Tech and wrote most of the Parity client. However, the decision to write about Parity was made by the other author, Andreas M. Antonopoulos, because Parity represents about 20% of the installed Ethereum client base.
 ====
 
 To install Parity, you can use the Rust package manager +cargo+ or download the source code from github. The package manager also downloads the source code, so there's not much difference between the two options. In the next section we will show you how to download and compile it yourself.


### PR DESCRIPTION
once again corrected-
20-25% of the ethereum network;
and as somewhere else statet before parity needs for building at least rust version 1.24