### PR TITLE
Update Dev Tools section with Ganache CLI Example

### DIFF
--- a/dev-tools.asciidoc
+++ b/dev-tools.asciidoc
@@ -344,7 +344,7 @@ Let's start a node simulation of the the Ethereum blockchain protocol.
 * [ ] Optionally enter a `--mnemonic` flag value to restore a previous HD wallet and associated addresses
 
 ----
-ganache-cli \
+$ ganache-cli \
   --networkId=3 \
   --port="8545" \
   --verbose \

--- a/dev-tools.asciidoc
+++ b/dev-tools.asciidoc
@@ -338,6 +338,20 @@ https://github.com/trufflesuite/ganache-cli/
 $ npm install -g ganache-cli
 ----
 
+Let's start a node simulation of the the Ethereum blockchain protocol.
+* [ ] Check the `--networkId` and `--port` flag values match your configuration in truffle.js
+* [ ] Check the `--gasLimit` flag value matches the latest Mainnet Gas Limit (i.e. 8000000 gas) shown at https://ethstats.net to avoid encountering `out of gas` exceptions unnecessarily. Note that a `--gasPrice` of 4000000000 represents a Gas Price of 4 gwei.
+* [ ] Optionally enter a `--mnemonic` flag value to restore a previous HD wallet and associated addresses
+
+----
+ganache-cli \
+  --networkId=3 \
+  --port="8545" \
+  --verbose \
+  --gasLimit=8000000 \
+  --gasPrice=4000000000;
+----
+
 
 === Embark
 


### PR DESCRIPTION
* Add example code to start Ganache CLI
* Add checklist to help ensure developers match the same Gas Price and Gas Limit values across both their truffle.js and Ganache CLI configurations to avoid `out of gas` exceptions and fully take advantage of the available limits that would be available to them on the Mainnet