### PR TITLE
Update Dev Tools section adding convenience of a NVM Hidden file and Engine configuration

### DIFF
--- a/dev-tools.asciidoc
+++ b/dev-tools.asciidoc
@@ -20,7 +20,7 @@ Documentation link; https://truffleframework.com/docs
 
 The truffle framework is made of several +NodeJS+ packages. Before we install +truffle+, we need to have an up-to-date and working installation of +NodeJS+ and the Node Package Manager (+npm+).
 
-The recommended way to install +NodeJS+ and +npm+, is to use the Node Version Manager, +nvm+. Once we install +nvm+, it will handle all the dependencies and updates for us. We'll follow the instructions found at:
+The recommended way to install +NodeJS+ and +npm+, is to use the Node Version Manager (NVM), +nvm+. Once we install +nvm+, it will handle all the dependencies and updates for us. We'll follow the instructions found at:
 http://nvm.sh
 
 Once +nvm+ is installed on your operating system, installing +NodeJS+ is simple. We use the +--lts+ flag to tell nvm that we want the most recent "Long Term Support (LTS)" version of +NodeJS+
@@ -36,6 +36,13 @@ $ node -v
 v8.9.4
 $ npm -v
 5.6.0
+----
+
+Create a hidden file .nvmrc that contains the Node.js version supported by your Dapp so developers just need to run `nvm install` in the root of the project directory and it will automatically install and switch to using that version.
+
+----
+$ node -v > .nvmrc
+$ nvm install
 ----
 
 Looking good. Now to install truffle:
@@ -119,6 +126,10 @@ $ npm install dotenv truffle-wallet-provider ethereumjs-wallet
 ----
 
 You now have a +node_modules+ directory with several thousand files, inside your Faucet directory.
+
+Prior to deploying the Dapp to a cloud production or continuous integration environment it is important to specify the `"engines"` field so you Dapp is built with the correct Node.js version and associated dependencies installed.
+
+Package.json "engines" field configuration link; https://docs.npmjs.com/files/package.json#engines
 
 ==== Configuring truffle
 


### PR DESCRIPTION
* Adding the .nvmrc hidden file in the root of the project directory is great for version control and developer convenience. If another developer clones the repository they simply need to have NVM installed and only need to run `nvm install` and it automatically installs and switches to using the Node.js version that is specified in the .nvmrc hidden file. If the developer switches between working on difference projects that each require a different version of Node.js, this saves time.
* Add a note about the importance of adding the "engine" field to the package.json configuration so that production and continuous integration environments know what version of Node.js to automatically install