### PR TITLE
Update Dev Tools section with both Web3.js API 0.2x.x and 1.0.0-beta.xx documentation links

### DIFF
--- a/dev-tools.asciidoc
+++ b/dev-tools.asciidoc
@@ -425,15 +425,17 @@ https://dapp.tools/hevm/
 
 == Libraries
 
-=== web3js
+=== web3.js
 
-web3js is the Ethereum compatible JS API for communicating with clients via JSON RPC, developed by the Ethereum foundation.
+web3.js is the Ethereum compatible JS API for communicating with clients via JSON RPC, developed by the Ethereum foundation.
 
 Github link; https://github.com/ethereum/web3.js
 
 +npm+ link; https://www.+npm+js.com/package/web3
 
-Documentation link; https://github.com/ethereum/wiki/wiki/JavaScript-API
+Documentation link for web3.js API 0.2x.x; https://github.com/ethereum/wiki/wiki/JavaScript-API
+
+Documentation link for web3.js API 1.0.0-beta.xx; https://web3js.readthedocs.io/en/1.0/web3.html
 
 === web3.py
 


### PR DESCRIPTION
Added both the Web3.js API 0.2x.x Document and Web3.js API 1.0.0-beta.xx (work in progress) links to avoid confusion, as some developers may install the latest version of Web3.js 1.0.0-beta-xx and then refer to the stable yet incorrect documentation link for Web3.js API 0.2x.x