### PR TITLE
Fixed typo

### DIFF
--- a/gas.asciidoc
+++ b/gas.asciidoc
@@ -62,7 +62,7 @@ In which case:
 
 Gas price is the amount in ether that the transaction sender is willing to pay for each unit of gas used. The miner who mines the next block gets to decide which transactions to include. Since gas price is factored into the transaction fee they will receive as a reward, they are more likely to include transactions with highest gas prices first. If the sender sets the gas price too low, they may have to wait a long time before their transaction makes it into a block.
 
-Miners can also decide the order in which transactions are included in a block. Since multiple miners are competing to append their block to the blockchain, the order of transactions within a block is arbitrarily decided by the "winning" miner and then the other miners verify with that order. While transactions from different accounts can be ordered arbitrarily, transactions from an individual accounts are executed in order of an auto-incrementing nonce.
+Miners can also decide the order in which transactions are included in a block. Since multiple miners are competing to append their block to the blockchain, the order of transactions within a block is arbitrarily decided by the "winning" miner and then the other miners verify with that order. While transactions from different accounts can be ordered arbitrarily, transactions from an individual account are executed in order of an auto-incrementing nonce.
 
 === Questions that need to be answered in this section
 


### PR DESCRIPTION
"transactions from an individual accounts are executed" -> "transactions from an individual account are executed"