### PR TITLE
Add http, websockets and ipc clients

### DIFF
--- a/code/jsonrpc/http/js/.gitignore
+++ b/code/jsonrpc/http/js/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/code/jsonrpc/http/js/README.md
+++ b/code/jsonrpc/http/js/README.md
@@ -1,0 +1,17 @@
+# Ethereum HTTP Client
+
+Connect to a node using HTTP(POST) and call the following rpc:
+- Get accounts associated with a node(Only you should be able to access these endpoint)
+- Get the current block number
+
+
+## Build Setup
+
+``` bash
+# install dependencies
+npm install
+
+# run the node script
+npm run http
+
+```

--- a/code/jsonrpc/http/js/index.js
+++ b/code/jsonrpc/http/js/index.js
@@ -1,0 +1,36 @@
+const axios = require("axios")
+const url = "http://172.16.163.129:8545"
+
+const requests = [
+  {
+    // Get the current block number
+    jsonrpc: "2.0",
+    method: "eth_blockNumber",
+    params: [],
+    id: 1234
+  },
+  {
+    // Get accounts on this node
+    jsonrpc: "2.0",
+    method: "eth_accounts",
+    params: [],
+    id: 12345
+  }
+]
+
+requests.map(async (request) => {
+  try {
+    // send the request
+    console.log("Call procedure: ", request.method)
+    const result = await axios.post(url, request)
+
+    // check for errors
+    if(result.data.error) 
+      console.log("Error: ", result.data.error.message)
+    else
+      console.log("Ethereum node response: ", result.data)
+  } catch (e) {
+    console.log("Error while connecting to the remote server", e)
+  }
+
+})

--- a/code/jsonrpc/ipc/client.go
+++ b/code/jsonrpc/ipc/client.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"sync"
+)
+
+// Request represents the jsonrpc2 request
+type Request struct {
+	Jsonrpc string      `json:"jsonrpc"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params"`
+	ID      uint64      `json:"id"`
+}
+
+// ReadIPC reads from a socket
+func ReadIPC(r io.Reader, wg *sync.WaitGroup) {
+	//20KB buffer
+	buf := make([]byte, 20*1024)
+	n, err := r.Read(buf[:])
+	if err != nil {
+		log.Fatal("Unable to read from socket", err)
+	}
+	fmt.Println("Ethereum node response: ", string(buf[0:n]))
+	wg.Done()
+}
+
+func main() {
+	var wg sync.WaitGroup
+	socketfile := "/home/younix/testnet/chaindata/geth.ipc"
+
+	// create a request
+	params := make([]int, 0)
+	request := &Request{
+		Jsonrpc: "2.0",
+		Method:  "eth_blockNumber",
+		Params:  params,
+		ID:      12345,
+	}
+
+	// marshal the struct to json string
+	strRequest, err := json.Marshal(&request)
+	if err != nil {
+		log.Fatal("Unable to encode request", err)
+	}
+
+	// dial the socket
+	ipc, err := net.Dial("unix", socketfile)
+	if err != nil {
+		log.Fatal("Unable to connect to the unix socket", err)
+	}
+	defer ipc.Close()
+
+	// listen for incoming messages
+	wg.Add(1)
+	go ReadIPC(ipc, &wg)
+
+	// write to the unix socket
+	fmt.Println("Call procedure: ", request.Method)
+	_, err = ipc.Write(strRequest)
+	if err != nil {
+		log.Fatal("Unable to write to the unix socket", err)
+	}
+
+	// wait for response
+	wg.Wait()
+}

--- a/code/jsonrpc/websockets/.gitignore
+++ b/code/jsonrpc/websockets/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/code/jsonrpc/websockets/README.md
+++ b/code/jsonrpc/websockets/README.md
@@ -1,0 +1,17 @@
+# Ethereum WS Client
+
+Connect to a node using Websockets and call the following rpc:
+- Get accounts associated with a node(Only you should be able to access these endpoint)
+- Get the current block number
+
+
+## Build Setup
+
+``` bash
+# install dependencies
+npm install
+
+# run the node script
+npm run rpc
+
+```

--- a/code/jsonrpc/websockets/app.js
+++ b/code/jsonrpc/websockets/app.js
@@ -1,0 +1,33 @@
+const WebSocket = require('ws');
+const wsEndpoint = "ws://172.16.163.129:8546"
+const ws = new WebSocket(wsEndpoint);
+
+const requests = [
+  {
+    // Get the current block number
+    jsonrpc: "2.0",
+    method: "eth_blockNumber",
+    params: [],
+    id: 1234
+  },
+  {
+    // Get accounts on this node
+    jsonrpc: "2.0",
+    method: "eth_accounts",
+    params: [],
+    id: 12345
+  }
+]
+
+// Connection is established
+ws.on('open', function open() {
+  requests.map((req) => { 
+    console.log("Call procedure: ", req.method)
+    ws.send(JSON.stringify(req)) 
+  })
+});
+
+// Listen for incoming messages
+ws.on('message', function incoming(data) {
+  console.log("Ethereum node response: ", JSON.parse(data));
+});


### PR DESCRIPTION
Added Http, websocket and IPC JSONRPC2.0 clients. The code only demonstrates the interaction with a node. 

The rpc methods are available here:
`https://github.com/ethereum/wiki/wiki/JSON-RPC`

