### PR TITLE
Added difference between different testnets

### DIFF
--- a/intro.asciidoc
+++ b/intro.asciidoc
@@ -129,11 +129,11 @@ As you can see on the MetaMask account page, you can choose between multiple Eth
 
 Main Ethereum Network:: The main, public, Ethereum blockchain. Real ETH, real value, real consequences.
 
-Ropsten Test Network:: Ethereum public test blockchain and network, using Proof-of-Work consensus (mining). ETH on this network has no value.
+Ropsten Test Network:: Ethereum public test blockchain and network, using Proof-of-Work consensus (mining). ETH on this network has no value. The issue with Ropsten was that the attacker minted tens of thousands of blocks, producing huge reorgs and pushing the gas limit up to 9B. A new public testnet was required then, but later(on 25th March 2017) Ropsten was also revived!
 
-Kovan Test Network:: Ethereum public test blockchain and network, using Proof-of-Authority consensus (federated signing). ETH on this network has no value.
+Kovan Test Network:: Ethereum public test blockchain and network, using "Aura" protocol for Proof-of-Authority consensus (federated signing). ETH on this network has no value. This test network is supported by "Parity" only. Other ethereum clients use 'Clique' protocol, which was proposed later, for Proof-of-Authority. 
 
-Rinkeby Test Network:: Ethereum public test blockchain and network, using Proof-of-Authority consensus (federated signing). ETH on this network has no value.
+Rinkeby Test Network:: Ethereum public test blockchain and network, using "Clique" protocol for Proof-of-Authority consensus (federated signing). ETH on this network has no value.
 
 Localhost 8545:: Connect to a node running on the same computer as the browser. The node can be part of any public blockchain (main or testnet), or a private testnet (see <<ganache>>).
 


### PR DESCRIPTION
 - Addresses the question, why so many different testnets are there.
 - Information about Ropsten regarding why it was abandoned.
 - Information about protocol used in kovan testnet and its support.
 - Information about the protocol used in rinkeby.

Address #198