### PR TITLE
[fix] Unclosed table in smart-contracts asciidoc

### DIFF
--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -180,3 +180,8 @@ Following is a list of notable GitHub contributors, including their GitHub ID in
   - Brian Guo (BrianGuo)
   - Lucas Switzer (LucasSwitz)
   - Ohad Koronyo (ohadh123)
+  - Alex Frolov (sashafrolov)
+  - Richard Sun (richardsfc)
+  - Brian Leffew (bleffew99)
+  - Giancarlo Pacenza (gpacenza)
+

--- a/smart-contracts.asciidoc
+++ b/smart-contracts.asciidoc
@@ -32,13 +32,13 @@ As you can see, there many languages to choose from. However, of all these Solid
 === Ethereum Contract ABI
 In computer software, an application binary interface (ABI) is an interface between two program modules; often, one at the level of machine code, and the other at the level of a program run by a user. An ABI defines how data structures and computational routines are accessed in *machine code*; this is not to be confused with an API, which defines this access in high-level, often human-readable format as *source code*. The ABI is thus the primary way of encoding and decoding data into and out of machine code.
 
-In Ethereum, the ABI is used to encode contract calls for the EVM and to read data out of transactions. As discussed in a previous section, an Ethereum smart contract is bytecode deployed on the blockchain under a *contract address*. The purpose of an ABI is to thus specify which functions in the contract to invoke and to get a guarantee that the function will return data in an expected format. 
+In Ethereum, the ABI is used to encode contract calls for the EVM and to read data out of transactions. As discussed in a previous section, an Ethereum smart contract is bytecode deployed on the blockchain under a *contract address*. The purpose of an ABI is to thus specify which functions in the contract to invoke and to get a guarantee that the function will return data in an expected format.
 
 ____
 If an account or a web application wants to interact with a published contract and use one of its functions, the account would first need to hash the function's definition through an ABI to create its *EVM bytecode*. Then, to call the function, the account would pass this bytecode to a transaction's data field so that the bytecode could be interpreted with code at the contract's address. Thus, the two necessary pieces of information for an external function call would be the *ABI* and the *address of the contract wherein the function is written*. We demontrate the use of an ABI in a detailed example below.
 ____
 
-The JSON format for a contract's ABI is given by an array of function and event descriptions. A function description is a JSON object with fields for `type`, `name`, `inputs`, `outputs`, `constant`, and `payable`. An event description object has fields for `type`, `name`, `inputs`, and `anonymous`. 
+The JSON format for a contract's ABI is given by an array of function and event descriptions. A function description is a JSON object with fields for `type`, `name`, `inputs`, `outputs`, `constant`, and `payable`. An event description object has fields for `type`, `name`, `inputs`, and `anonymous`.
 
 The ABI thus specifies information about functions in a smart contract, relaying information such as inputs and types. However, the ABI *only* contains information about functions and events, meaning it will not hold values for fields such as state variables or modifiers.
 
@@ -46,9 +46,9 @@ The ABI thus specifies information about functions in a smart contract, relaying
 ==== Structure of Call Data
 The data for a function call is a concatenation of several values of bytes. We discuss these in steps below.
 
-*First Four Bytes*: The call data always begins with *four bytes* of the function signature. In specific, these are the first four bytes of the Keccak-256 hash of the *signature* of a function. In this context, the signature is simply the function name with a parenthesised list of parameter types split by a single comma. 
+*First Four Bytes*: The call data always begins with *four bytes* of the function signature. In specific, these are the first four bytes of the Keccak-256 hash of the *signature* of a function. In this context, the signature is simply the function name with a parenthesised list of parameter types split by a single comma.
 
-Assume, as a running example, the brief contract `Test`: 
+Assume, as a running example, the brief contract `Test`:
 
 [source,solidity]
 contract Test {
@@ -76,18 +76,18 @@ ____
 //TO-DO: Discuss Events vs. Functions
 
 ==== Further Reading
-The Application Binary Interface (ABI) is strongly typed, known at compilation time and static. All contracts have the interface definitions of any contracts they intend to call available at compile-time. 
+The Application Binary Interface (ABI) is strongly typed, known at compilation time and static. All contracts have the interface definitions of any contracts they intend to call available at compile-time.
 
-A more rigorous and in-depth explanation of the Ethereum ABI can be found at 
-`https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI`. 
+A more rigorous and in-depth explanation of the Ethereum ABI can be found at
+`https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI`.
 The link includes details about the formal specification of encoding and various helpful examples.
 
 [[testing_frameworks]]
 === Testing Smart Contracts
 
 === Deploying Smart Contracts
-After you've typed up your smart contract, you'll want to deploy it to the main ethereum network. 
-The process is as follows: 
+After you've typed up your smart contract, you'll want to deploy it to the main ethereum network.
+The process is as follows:
 
 1. Compile your source solidity code to EVM bytecode
 2. Sign the bytecode into a transaction
@@ -185,20 +185,20 @@ Finally, deploy it to the network!
 //TODO use the example from the intro, incorporate infura, truffle deployment?, and expand on intro
 
 
-==== Testing Frameworks 
+==== Testing Frameworks
 There are several commonly-used test frameworks (no particular order)
 
 Truffle Test:: Part of the Truffle framework, Truffle allows for unit tests to be written in Javascript (Mocha based) or Solidity. These tests are run against TestRPC/Ganache. More details on writing these tests are located at <<truffle>>
 
-Embark Framework Testing:: Embark integrates with Mocha to run unit tests written in Javascript. The tests are in turn run against contracts deployed on TestRPC/Ganache. The Embark Framework automatically deploys smart contracts and will automatically redeploy the contracts when they are changed. It also keeps track of deployed contracts and deploys contracts when truly needed. Embark includes a testing lib to rapidly run and test your contracts in a EVM, with functions like ```assert.equal()```. ```embark test``` will run any test files under directory test/. 
+Embark Framework Testing:: Embark integrates with Mocha to run unit tests written in Javascript. The tests are in turn run against contracts deployed on TestRPC/Ganache. The Embark Framework automatically deploys smart contracts and will automatically redeploy the contracts when they are changed. It also keeps track of deployed contracts and deploys contracts when truly needed. Embark includes a testing lib to rapidly run and test your contracts in a EVM, with functions like ```assert.equal()```. ```embark test``` will run any test files under directory test/.
 
-Dapp:: Dapp uses native Solidity code (a library called ds-test) and a Parity built Rust library called Ethrun to execute Ethereum byte code and then assert correctness. The ds-test library provides assertion functions for validating correctness and events for logging data in the console. 
+Dapp:: Dapp uses native Solidity code (a library called ds-test) and a Parity built Rust library called Ethrun to execute Ethereum byte code and then assert correctness. The ds-test library provides assertion functions for validating correctness and events for logging data in the console.
 
-Assertions Functions includes 
+Assertions Functions includes
 ....
-assert(bool condition)  
+assert(bool condition)
 assertEq(address a, address b)
-assertEq(bytes32 a, bytes32 b)  
+assertEq(bytes32 a, bytes32 b)
 assertEq(int a, int b)
 assertEq(uint a, uint b)
 assertEq0(bytes a, bytes b)
@@ -240,6 +240,7 @@ Then finally deploy your contract with:
 > var deploy = {from eth.coinbase, data:byteCode, gas:2000000}
 > var fooInstance = foo(bar, baz)
 ----
+=======
 
 ==== On-Blockchain Testing
 Although most testing shouldn't occur on deployed contracts, a contract's behavior can be checked via Ethereum clients.  The following commands can be used to assess a smart comtract's state. These commands should be typed at the '+geth+' terminal, although any web3 calls will also support these commands.
@@ -271,7 +272,7 @@ Two of the most important concepts to consider during smart contract creation ar
 
 * An exception is thrown
 * The state of the contract prior to the function's execution is restored
-* The entire amount of the gas is given to the miner as a transaction fee, it is *not* refunded 
+* The entire amount of the gas is given to the miner as a transaction fee, it is *not* refunded
 
 Because gas is paid for by the user who creates that transaction, users are discouraged from calling functions that have a high gas cost. It is thus in the programmer's best interest to minimize the gas cost of a contract's functions. To this end, there are certain practices that are recommended when constructing smart contracts, so as to minimize the gas costs surrounding a function call.
 
@@ -310,15 +311,15 @@ To guard against re-entrancy, http://solidity.readthedocs.io/en/v0.4.21/security
 ==== Design Patterns
 
 Software developers of any programming paradigm generally experience reoccuring design challenges centered around the topics of behavior, structure, interaction, and creation. Often these problems can be generalized
-and re-applied to future problems of a similar nature. When given a formal structure, these generalizations are called *Design Patterns*. 
-Smart Contracts have their own set of reoccuring design problems that can be solved using some of the patterns described below. 
+and re-applied to future problems of a similar nature. When given a formal structure, these generalizations are called *Design Patterns*.
+Smart Contracts have their own set of reoccuring design problems that can be solved using some of the patterns described below.
 
 There are an endless number of design problems in the development of smart contracts, making it impossible to discuss all of them
 here. For that reason, this section will focus on three of the most pervasive problem classifications in smart contract design: *access control*, *state flow*, and *fund dispersement*.
 
 Throughout this section, we will be working with a contract that will ultimately incorporate all three of these design patterns. This contract will run a voting system that
 allows users to vote on "truth". The contract will suggest a claim such as "The Cubs won the World Series." or "It is raining in New York City" and then users will have
-the opportunity to vote either true or false. The contract will consider the proposition as true if the majority of participants voted for true and likewise if the majority 
+the opportunity to vote either true or false. The contract will consider the proposition as true if the majority of participants voted for true and likewise if the majority
 of participants voted for false. To incentivize truthfulness, every vote must send 100 ether to the contract and the funds contributed by the losing minority will be split up amongst
 the majority. Every participant in the majority will receive their portion of winnings from the minority as well as their initial investment.
 
@@ -327,7 +328,7 @@ This "truth voting" system is actually the foundation of Gnosis, a forcasting to
 ===== Access Control
 
 
-Access control restricts which users may call contract functions. For the example, the owner of the truth voting contract may decide to limit those who can participate in the vote. 
+Access control restricts which users may call contract functions. For the example, the owner of the truth voting contract may decide to limit those who can participate in the vote.
 To accomplish this the contract must impose two access restrictions:
 
 . Only a owner of the contract may add new users to the list of "allowed voters"
@@ -376,7 +377,7 @@ contract TruthVote{
     }
 
     function vote(bool val)
-    public 
+    public
     onlyVoter()
     hasNotVoted(){
         if(msg.value >= VOTE_COST){
@@ -392,7 +393,7 @@ contract TruthVote{
 *Description of Modifiers and Functions:*
 
 - *onlyOwner*: this modifier can decorate a function such that the function will then only be callable by a sender with an address that matches that of *owner*.
-- *onlyVoter*: this modifer can decorate a function such that the function will then only be callable by a registered voter. 
+- *onlyVoter*: this modifer can decorate a function such that the function will then only be callable by a registered voter.
 - *addVoter(voter)*: this function is used to add a voter to the list of voters. This function uses the *onlyOwner* modifier so only the owner of this contract may call it.
 - *vote(val)*: this function is used by a voter to vote either true or false to the presented proposition. It is decorated with the *onlyVoter* modifer so only registered voters may call it.
 
@@ -403,9 +404,9 @@ at a given point in time. Let's return to our truth voting system for a more con
 
 The operation of our voting system can be broken down into 3 distinct states.
 
-. *Register*: The service has been created and the owner can now add voters. 
-. *Vote*:  All voters cast their votes. 
-. *Disperse*: Vote payments are divided and sent to the majority participants. 
+. *Register*: The service has been created and the owner can now add voters.
+. *Vote*:  All voters cast their votes.
+. *Disperse*: Vote payments are divided and sent to the majority participants.
 
 The following code continues to build on the access control code, but further restricts functionality to specific states.
 In Solidity, it is commonplace to use enumerated values to represent states.
@@ -425,13 +426,13 @@ contract TruthVote{
 
     address[] trueVotes;
     address[] falseVotes;
-    
+
 
     mapping (address => bool) voters;
     mapping (address => bool) hasVoted;
 
     uint VOTE_COST = 100;
-    
+
     States state;
 
     modifier onlyOwner(){
@@ -448,7 +449,7 @@ contract TruthVote{
             require(state == _stage);
             _;
         }
-        
+
     modifier hasNotVoted(){
         require(hasVoted[msg.sender] == false);
         _;
@@ -478,7 +479,7 @@ contract TruthVote{
     }
 
     function vote(bool val)
-    public 
+    public
     isCurrentState(States.VOTE)
     onlyVoter()
     hasNotVoted(){
@@ -487,7 +488,7 @@ contract TruthVote{
                 trueVotes.push(msg.sender);
             else
                 falseVotes.push(msg.sender);
-                
+
             hasVoted[msg.sender] = true;
         }
     }
@@ -501,11 +502,11 @@ contract TruthVote{
         uint winningCompensation;
         if(trueVotes.length > falseVotes.length){
             winningGroup = trueVotes;
-            winningCompensation = VOTE_COST + (VOTE_COST*falseVotes.length) / trueVotes.length; 
+            winningCompensation = VOTE_COST + (VOTE_COST*falseVotes.length) / trueVotes.length;
         }
         else if(trueVotes.length < falseVotes.length){
             winningGroup = falseVotes;
-            winningCompensation = VOTE_COST + (VOTE_COST*trueVotes.length) / falseVotes.length; 
+            winningCompensation = VOTE_COST + (VOTE_COST*trueVotes.length) / falseVotes.length;
         }
         else
         {
@@ -530,9 +531,9 @@ contract TruthVote{
 - *disperse*: function that calculates the majority and disperses winnings accordingly. Only the owner may call this function to officially close voting.
 - *startVote*: function that the owner can use to start a vote.
 
-It may be important to note that allowing the owner to close the voting process at will opens this contract up to abuse. In a more geniune implemenation the voting period should close after a publicly understood period of time. For the sake of this example, this is fine. 
+It may be important to note that allowing the owner to close the voting process at will opens this contract up to abuse. In a more geniune implemenation the voting period should close after a publicly understood period of time. For the sake of this example, this is fine.
 
-The additions made now ensure that voting is only allowed when the owner decides to start the voting period, users can only be registered by the owner before the vote happens, and funds are only dispered after the vote closes. 
+The additions made now ensure that voting is only allowed when the owner decides to start the voting period, users can only be registered by the owner before the vote happens, and funds are only dispered after the vote closes.
 
 ===== Widthraw
 Many contracts will offer some way for a user to retrieve money from it. In our working example, users of the majority are sent money directly when the contract
@@ -564,7 +565,7 @@ modifier posttransition(){
 }
 
 function vote(bool val)
-public 
+public
 onlyVoter()
 isCurrentStage(State.VOTE){
     if(votes[msg.sender] == address(0) && msg.value >= VOTE_COST){
@@ -585,11 +586,11 @@ posttransition()
 {
     if(trueCount > falseCount){
         winner = true;
-        winningCompensation = VOTE_COST + (VOTE_COST*false_votes.length) / true_votes.length; 
+        winningCompensation = VOTE_COST + (VOTE_COST*false_votes.length) / true_votes.length;
     }
     else if(falseCount > trueCount){
         winner = false;
-        winningCompensation = VOTE_COST + (VOTE_COST*true_votes.length) / false_votes.length; 
+        winningCompensation = VOTE_COST + (VOTE_COST*true_votes.length) / false_votes.length;
     }else{
         winningCompensation = VOTE_COST;
     }
@@ -603,7 +604,7 @@ isCurrentState(State.WITHDRAW){
         if(votes[msg.sender] == winner){
             msg.sender.send(winningCompensation);
         }
-    }    
+    }
 }
 
 ...
@@ -612,7 +613,7 @@ isCurrentState(State.WITHDRAW){
 *Description of Modifiers and (Updated) Functions:*
 
 - *posttransition*: transitions to the next state after the function call
-- *determine*: this function is very similar to the previous *disperse* function execpt it now just calculates the winner and winning compensation and does not actually send any funds. 
+- *determine*: this function is very similar to the previous *disperse* function execpt it now just calculates the winner and winning compensation and does not actually send any funds.
 - *vote*: votes are now added to the votes mapping and true/false counters are incremented.
 - *widthdraw*: allows a voter to collect winnings (if any).
 


### PR DESCRIPTION
Also fixed unclosed table in smart-contracts

Note: the formatter that I was using automatically removed unnecessary spaces from the end of lines. The only line I actually changed was the unclosed block, line 243, which caused formatting issues in the rest of the doc