### PR TITLE
Some restructuring of the article and ETC Testnets

### DIFF
--- a/ethereum-testnets.asciidoc
+++ b/ethereum-testnets.asciidoc
@@ -63,6 +63,15 @@ https://www.rinkeby.io/
 
 https://rinkeby.etherscan.io/
 
+== Ethereum Classic
+
+=== Morden
+Ethereum Classic currently runs a variant of the Morden testnet that is kept at feature parity with the Ethereum Classic live network. You can connect to it through either the gastracker RPC or by providing a flag to `geth` or `parity`
+
+*Faucet:* http://testnet.epool.io/
+*Gastracker RPC:* https://web3.gastracker.io/morden
+*Geth flag:* `geth --chain=morden`
+*Parity flag:* `parity --chain=classic-testnet`
 
 == Virtual Machine and Cloud Deployment
 

--- a/ethereum-testnets.asciidoc
+++ b/ethereum-testnets.asciidoc
@@ -1,8 +1,8 @@
 == Testnet Overview
 === What is a testnet?
 
-A test network is used to simulate the behavior of a main network. There are some publicly available test networks.
-When any major change is about to be included in the a main network, its tests are mostly done on these test networks.
+A test network is used to simulate the behavior of the main network. There are some publicly available test networks.
+When any major change is about to be included in the main network, its tests are mostly done on these test networks.
 These test networks are also used by a large number of developers for testing their applicactions before deploying them on the main network. 
 
 === Using Testnets
@@ -26,15 +26,17 @@ MetaMask includes a secure identity vault, providing a user interface to manage 
 on different sites and sign blockchain transactions. You can install the MetaMask add-on in
 Chrome, Firefox, Opera, and the new Brave browser. 
 
-== Ethereum
+== Connecting to Testnets
 
-=== Infura
+=== Ethereum
+
+==== Infura
 
 Infura was born with the goal of delivering stable and reliable RPC access to the internal projects within ConsenSys.
 As the Ethereum network began to grab the majority of blockchain developer mindshare, ConsenSys recognized
 that Infura would be of broad interest to the entire ecosystem. It provides access to Ethereum APIs and IPFS gateways.
 
-=== Ropsten
+==== Ropsten
 
 If you want to begin testing contracts on the Ropsten network, there are several faucets that you can
 source your Ropsten ethers from. If a faucet does not work, try a different one.
@@ -53,17 +55,27 @@ A ropsten faucet available at https://faucet.bitfwd.xyz/.
 * Kyber Network Ropsten Faucet
 Another ropsten faucet available at https://faucet.kyber.network/.
 
-=== Rinkeby
+==== Rinkeby
 
 The Rinkeby faucet is located at https://faucet.rinkeby.io/.
 To request test ether it is necessary to make a public post on either Twitter, Goole Plus or Facebook.
 
-=== Kovan
+==== Kovan
 
 The Kovan testnet supports various methods to request test ether.
 Further information can be found in the Kovan testnet GitHub Repository located at https://github.com/kovan-testnet/faucet/blob/master/README.md.
 
-=== History of Ethereum Testnets
+=== Ethereum Classic
+
+==== Morden
+Ethereum Classic currently runs a variant of the Morden testnet that is kept at feature parity with the Ethereum Classic live network. You can connect to it through either the gastracker RPC or by providing a flag to `geth` or `parity`
+
+*Faucet:* http://testnet.epool.io/
+*Gastracker RPC:* https://web3.gastracker.io/morden
+*Geth flag:* `geth --chain=morden`
+*Parity flag:* `parity --chain=classic-testnet`
+
+== History of Ethereum Testnets
 
 https://www.ethnews.com/ropsten-to-kovan-to-rinkeby-ethereums-testnet-troubles
 

--- a/ethereum-testnets.asciidoc
+++ b/ethereum-testnets.asciidoc
@@ -26,15 +26,17 @@ MetaMask includes a secure identity vault, providing a user interface to manage 
 on different sites and sign blockchain transactions. You can install the MetaMask add-on in
 Chrome, Firefox, Opera, and the new Brave browser. 
 
-== Ethereum
+== Connecting to Testnets
 
-=== Infura
+=== Ethereum
+
+==== Infura
 
 Infura was born with the goal of delivering stable and reliable RPC access to the internal projects within ConsenSys.
 As the Ethereum network began to grab the majority of blockchain developer mindshare, ConsenSys recognized
 that Infura would be of broad interest to the entire ecosystem. It provides access to Ethereum APIs and IPFS gateways.
 
-=== Ropsten
+==== Ropsten
 
 If you want to begin testing contracts on the Ropsten network, there are several faucets that you can
 source your Ropsten ethers from. If a faucet does not work, try a different one.
@@ -53,17 +55,27 @@ A ropsten faucet available at https://faucet.bitfwd.xyz/.
 * Kyber Network Ropsten Faucet
 Another ropsten faucet available at https://faucet.kyber.network/.
 
-=== Rinkeby
+==== Rinkeby
 
 The Rinkeby faucet is located at https://faucet.rinkeby.io/.
 To request test ether it is necessary to make a public post on either Twitter, Goole Plus or Facebook.
 
-=== Kovan
+==== Kovan
 
 The Kovan testnet supports various methods to request test ether.
 Further information can be found in the Kovan testnet GitHub Repository located at https://github.com/kovan-testnet/faucet/blob/master/README.md.
 
-=== History of Ethereum Testnets
+=== Ethereum Classic
+
+==== Morden
+Ethereum Classic currently runs a variant of the Morden testnet that is kept at feature parity with the Ethereum Classic live network. You can connect to it through either the gastracker RPC or by providing a flag to `geth` or `parity`
+
+*Faucet:* http://testnet.epool.io/
+*Gastracker RPC:* https://web3.gastracker.io/morden
+*Geth flag:* `geth --chain=morden`
+*Parity flag:* `parity --chain=classic-testnet`
+
+== History of Ethereum Testnets
 
 https://www.ethnews.com/ropsten-to-kovan-to-rinkeby-ethereums-testnet-troubles
 


### PR DESCRIPTION
Restructured a bit so that general information on the purpose of testnets is better separated from the details of connecting to/using them.

Also added ETC testnet details.

I'm wondering too if we should adapt this so that each testnet has the type of template I specified for ETC, this would cleanup the `History of Ethereum Testnets` section quite a bit as at the moment it seems to contain various links that may be better suited to their specific sections.