### PR TITLE
smart-contracts: fixed typos in two sections

### DIFF
--- a/smart-contracts.asciidoc
+++ b/smart-contracts.asciidoc
@@ -27,7 +27,7 @@ Vyper:: A more recently developed language, similar to Serpent and with Python-l
 
 Bamboo:: A newly developed language, influenced by Erlang with explicit state transitions and without iterative flows (loops). Intended to reduce side-effects and increase auditability. Very new and rarely used.
 
-As you can see, there many languages to choose from. However, of all these Solidity is by far the most popular, to the point of being the de-facto high-level language of Ethereum and even other EVM-like blockchains. We will spend most of our time using Solidity, but will also explore some of the examples in other high-level languages, to gain an understanding of their different philosophies.
+As you can see, there are many languages to choose from. However, of all these Solidity is by far the most popular, to the point of being the de-facto high-level language of Ethereum and even other EVM-like blockchains. We will spend most of our time using Solidity, but will also explore some of the examples in other high-level languages, to gain an understanding of their different philosophies.
 
 === Building a Smart Contract
 
@@ -276,7 +276,7 @@ Two of the most important concepts to consider during smart contract creation ar
 * The state of the contract prior to the function's execution is restored
 * The entire amount of the gas is given to the miner as a transaction fee, it is *not* refunded
 
-Because gas is paid for by the user who creates that transaction, users are discouraged from calling functions that have a high gas cost. It is thus in the programmer's best interest to minimize the gas cost of a contract's functions. To this end, there are certain practices that are recommended when constructing smart contracts, so as to minimize the gas costs surrounding a function call.
+Because gas is paid by the user who creates that transaction, users are discouraged from calling functions that have a high gas cost. It is thus in the programmer's best interest to minimize the gas cost of a contract's functions. To this end, there are certain practices that are recommended when constructing smart contracts, so as to minimize the gas costs surrounding a function call.
 
 *Avoid dynamically-sized Arrays*
 


### PR DESCRIPTION
"Introduction to Ethereum High-Level Languages" and "Best Practices" sections