### PR TITLE
assert and require solidity sentences added

### DIFF
--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -21,6 +21,11 @@ Account::
 Address::
     Most generally, this is the place where you receive transactions on the blockchain. More specifically, it is the right most 160-bits of a Keccak hash of an ECDSA public key.
 
+Assert::
+    In Solidity assert() compiles to *0xfe*, which is an invalid opcode, using up all remaining gas, and reverting all changes.
+    When an assert() statement fails, something very wrong and unexpected shoud be happening, and you will need to fix your code.
+    You should use assert to avoid conditions which should never, ever be possible.
+
 // What is the case convention - bitcoin or Bitcoin?
 Big-endian::
     A positional number representation where the most significant digit is first. The opposite of little-endian where the least significant digit is first.

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -176,6 +176,12 @@ Reentrancy Attack::
   This recursive call can be implemented from a fallback function of the Attacker contract.
   The only trick that the attacker has to perform is to break that recursive call before running out of gas and so avoiding the stolen ether be reverted.
 
+Require::
+    In Solidity require() compiles to *0xfd* which is the *REVERT* opcode. The REVERT instruction provides a way to stop execution and revert state changes, without consuming all provided gas and with the ability to return a reason. +
+    The require function should be used to ensure valid conditions, such as inputs, or contract state variables are met, or to validate return values from calls to external contracts. +
+    Prior to the *Byzantium* network upgrade there were two practical ways to revert a transaction: running out of gas or executing an invalid instruction. Both of these options consumed all remaining gas. +
+    When you look up this opcode in the *Yellow Paper* prior to the *Byzantium* network upgrade, you can't find it and because there was no specification for that opcode, when the EVM reached it, it thrown an _invalid opcode error_. +
+
 Reward::
     An amount, in Ether (ETH), included in each new block as a reward by the network to the miner who found the Proof-of-Work solution.
 

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -9,6 +9,9 @@ Please add terms here, by doing a pull request!
 
 If you can't write a definition, then do a pull request to add only the words you think should be defined and leave the definition empty for someone else to add later.
 
+Comment from Gitter:
+    Andreas M. Antonopoulos @aantonop mar. 26 19:42 (2018)
+    Capitalize ALL THE WORDS
 
 ////
 

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -176,11 +176,16 @@ Reentrancy Attack::
   This recursive call can be implemented from a fallback function of the Attacker contract.
   The only trick that the attacker has to perform is to break that recursive call before running out of gas and so avoiding the stolen ether be reverted.
 
+[require-sentence]
 Require::
     In Solidity require(false) compiles to *0xfd* which is the *REVERT* opcode. The REVERT instruction provides a way to stop execution and revert state changes, without consuming all provided gas and with the ability to return a reason. +
     The require function should be used to ensure valid conditions, such as inputs, or contract state variables are met, or to validate return values from calls to external contracts. +
     Prior to the *Byzantium* network upgrade there were two practical ways to revert a transaction: running out of gas or executing an invalid instruction. Both of these options consumed all remaining gas. +
     When you look up this opcode in the *Yellow Paper* prior to the *Byzantium* network upgrade, you can't find it and because there was no specification for that opcode, when the EVM reached it, it thrown an _invalid opcode error_. +
+
+Revert::
+    Use revert() when you need to handle the same type of situations as <<require-sentence, require()>> but with more complex logic.
+    For instances, if your code have some nested if/else logic flow, you will find that it makes sense to use  <<require-sentence, require()>> instead of require().
 
 Reward::
     An amount, in Ether (ETH), included in each new block as a reward by the network to the miner who found the Proof-of-Work solution.

--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -22,7 +22,7 @@ Address::
     Most generally, this is the place where you receive transactions on the blockchain. More specifically, it is the right most 160-bits of a Keccak hash of an ECDSA public key.
 
 Assert::
-    In Solidity assert() compiles to *0xfe*, which is an invalid opcode, using up all remaining gas, and reverting all changes.
+    In Solidity assert(false) compiles to *0xfe*, which is an invalid opcode, using up all remaining gas, and reverting all changes.
     When an assert() statement fails, something very wrong and unexpected shoud be happening, and you will need to fix your code.
     You should use assert to avoid conditions which should never, ever be possible.
 
@@ -177,7 +177,7 @@ Reentrancy Attack::
   The only trick that the attacker has to perform is to break that recursive call before running out of gas and so avoiding the stolen ether be reverted.
 
 Require::
-    In Solidity require() compiles to *0xfd* which is the *REVERT* opcode. The REVERT instruction provides a way to stop execution and revert state changes, without consuming all provided gas and with the ability to return a reason. +
+    In Solidity require(false) compiles to *0xfd* which is the *REVERT* opcode. The REVERT instruction provides a way to stop execution and revert state changes, without consuming all provided gas and with the ability to return a reason. +
     The require function should be used to ensure valid conditions, such as inputs, or contract state variables are met, or to validate return values from calls to external contracts. +
     Prior to the *Byzantium* network upgrade there were two practical ways to revert a transaction: running out of gas or executing an invalid instruction. Both of these options consumed all remaining gas. +
     When you look up this opcode in the *Yellow Paper* prior to the *Byzantium* network upgrade, you can't find it and because there was no specification for that opcode, when the EVM reached it, it thrown an _invalid opcode error_. +


### PR DESCRIPTION
For clarification of its current important differences and historical similarities, assert and require solidity sentences have been added.

Also added a comment of Andreas from Gitter regarding the capitalization of words.

One anchor added.

Returned to LF (line feed) format.