### PR TITLE
Decorators are dealt with logically by  compiler

### DIFF
--- a/contrib/vyper.asciidoc
+++ b/contrib/vyper.asciidoc
@@ -37,6 +37,8 @@ Constant decorator - Functions which start with the constant decorator are not a
 
 Payable decorator - Only functions which declare the @payable decorator at the start will be allowed to transfer value.
 
+Vyper implements the logic of decorators explicitly. For example the Vyper code compilation process will fail if a function is preceeded with both a payable decorator and a constant decorator. Of course this makes sense because a constant function (one which only reads from the global state) should never need to partake in a transfer of value.
+
 === Online code editor and compiler
 Vyper has its own online code editor and compiler at the following URL < https://vyper.online >. This Vyper online compiler allows you to write and then compile your smart contracts into Bytecode, ABI and LLL using only your web browser. The Vyper online compiler has a variety of pre written smart contracts for your convenience. These include a simple open auction, safe remote purchases, ERC20 token and more.
 


### PR DESCRIPTION
Certain pairs of decorators will never be combined. If an illogical set of decorators precede a function, the compilation process will fail.