### PR TITLE
Adding more examples of compiler decorator logic

### DIFF
--- a/contrib/vyper.asciidoc
+++ b/contrib/vyper.asciidoc
@@ -37,7 +37,7 @@ Constant decorator - Functions which start with the constant decorator are not a
 
 Payable decorator - Only functions which declare the @payable decorator at the start will be allowed to transfer value.
 
-Vyper implements the logic of decorators explicitly. For example the Vyper code compilation process will fail if a function is preceeded with both a payable decorator and a constant decorator. Of course this makes sense because a constant function (one which only reads from the global state) should never need to partake in a transfer of value.
+Vyper implements the logic of decorators explicitly. For example, the Vyper code compilation process will fail if a function is preceeded with both a payable decorator and a constant decorator. Of course this makes sense because a constant function (one which only reads from the global state) should never need to partake in a transfer of value. Also, each Vyper function must be preceeded with either the @public or the @private decorator to avoid compilation failure. Preceeding a Vyper function with both a @public decorator and a @private decorator will also result in a compilation failure.
 
 === Online code editor and compiler
 Vyper has its own online code editor and compiler at the following URL < https://vyper.online >. This Vyper online compiler allows you to write and then compile your smart contracts into Bytecode, ABI and LLL using only your web browser. The Vyper online compiler has a variety of pre written smart contracts for your convenience. These include a simple open auction, safe remote purchases, ERC20 token and more.


### PR DESCRIPTION
I have verified that accidentally using other illogical combinations of function decorators will result in compilation failure. For example using both public and private together or using no access modifiers at all.