### PR TITLE
fix transaction pubkey recovery

### DIFF
--- a/transactions.asciidoc
+++ b/transactions.asciidoc
@@ -497,7 +497,7 @@ https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md
 
 As mentioned in <<tx_struct>>, the transaction message doesn't include any "from" field. That's because the originator's public key can be computed directly from the ECDSA signature. Once you have the public key, you can compute the address easily. The process of recovering the signer's public key is called a _Public Key Recovery_.
 
-Given the values +r+ and +s+, that were computed in <<ecdsa_math>>, we can compute two possible public keys, only one of which will produce a valid +P+ result in our ECDSA verification function. The one that produces a valid +P+ is the correct public key.
+Given the values +r+ and +s+, that were computed in <<ecdsa_math>>, we can compute two possible public keys.
 
 First, we compute two elliptic curve points R and R^'^, from the x coordinate +r+ value that is in the signature. There are two points, because the elliptic curve is symmetric across the x-axis, so that for any value +x+, there are two possible values that fit the curve, on either side of the x-axis.
 
@@ -521,8 +521,6 @@ where:
 * R and R^'^ are the two possibilities for the ephemeral public key _Q_
 * z are the n-lowest bits of the message hash
 * G is the elliptic curve generator point
-
-Plug each of the two possible K values into the signature verification function and one will verify - that's the owner's public key.
 
 To make things more efficient, the transaction signature includes a prefix value +v+, which tells us which of the two possible R values are the ephemeral public key. If +v+ is even, then R is the correct value. If +v+ is odd, then R^'^. That way, we need to calculate only one value for R and only one value for K.
 


### PR DESCRIPTION
remove transaction pubkey recovery wrong description.

> Given the values r and s, that were computed in ECDSA Math, we can compute two possible public keys, only one of which will produce a valid P result in our ECDSA verification function. The one that produces a valid P is the correct public key.

I guess there is a typo, which P should be Q. Anyway, I think the two possible public keys will produce two valid points on elliptic curve which x coordinate of both equal r. 

So we should use v directly to determine valid R and pubKey.