### PR TITLE
Add instructions for interactig with geth testnets

### DIFF
--- a/clients.asciidoc
+++ b/clients.asciidoc
@@ -155,7 +155,7 @@ For other operating systems, use the package manager of your OS or follow the Wi
 
 Now you have +git+, +golang+, +rust+, and necessary libraries installed, let's get to work!
 
-[[Go-Ethereum]]
+[[go_ethereum_geth]]
 ==== Go-Ethereum (Geth)
 
 There are three original implementations of the Ethereum client written in three different languages: C++, Python, and Go. Geth is the Go language implementation, which is actively developed and considered the "official" implementation of the Ethereum client. There is some debate on the meaning of the title "official client" in a decentralized system such as Ethereum, but suffice it to say that Geth is supported by the Ethereum Foundation, a Swiss non-profit organization founded by Ethereum's creator, Vitalik Buterin.

--- a/clients.asciidoc
+++ b/clients.asciidoc
@@ -155,6 +155,7 @@ For other operating systems, use the package manager of your OS or follow the Wi
 
 Now you have +git+, +golang+, +rust+, and necessary libraries installed, let's get to work!
 
+[[Go-Ethereum]]
 ==== Go-Ethereum (Geth)
 
 There are three original implementations of the Ethereum client written in three different languages: C++, Python, and Go. Geth is the Go language implementation, which is actively developed and considered the "official" implementation of the Ethereum client. There is some debate on the meaning of the title "official client" in a decentralized system such as Ethereum, but suffice it to say that Geth is supported by the Ethereum Foundation, a Swiss non-profit organization founded by Ethereum's creator, Vitalik Buterin.

--- a/ethereum-testnets.asciidoc
+++ b/ethereum-testnets.asciidoc
@@ -27,7 +27,7 @@ Geth natively supports both the Ropsten and Rinkeby networks. To connect to the 
 ----
 geth --testnet
 ----
-This will start syncing the Ropsten blockchain. A new directory named 'testnet' will be created in you main Ethereum data directory. A 'keystore' directory will be create inside 'testnet' and will store the private keys of you testnet accounts. As of writing this, the Ropsten blockchain is significantly smaller than the main Ethereum blockchain, and consists of about 14GB of data. Since the testnet requires less resouces, it is simpler to setup and test your code on the testnet first.
+This will start syncing the Ropsten blockchain. A new directory named 'testnet' will be created in your main Ethereum data directory. A 'keystore' directory will be created inside 'testnet' and will store the private keys of your testnet accounts. As of writing this, the Ropsten blockchain is significantly smaller than the main Ethereum blockchain and consists of about 14GB of data. Since the testnet requires fewer resources, it is simpler to setup and test your code on the testnet first.
 
 
 Interacting with the tesnet is similar to the Mainnet. You can start geth testnet with a console, by running:
@@ -35,24 +35,24 @@ Interacting with the tesnet is similar to the Mainnet. You can start geth testne
 geth --testnet console
 ----
 
-This makes it possible to perform operations such as opening a new account, checking you balance, checking the balance of other Ethereum addresses, etc.
+This makes it possible to perform operations such as opening a new account, checking your balance, checking the balance of other Ethereum addresses, etc.
 When running outside of the geth console, operations can be performed similarly to how they would have been performed on the Mainnet, simply by adding the --testnet parameter to the command-line instruction. As an example to list all the available testnet accounts and their addresses, run:
 ----
 geth --testnet account list
 ----
 
-More on setting up geth at: <<clients.asciidoc#Go-Ethereum,Go-Ethereum (Geth)>>
+More on setting up geth at: <<clients.asciidoc#go_ethereum_geth,Go-Ethereum (Geth)>>
 
 [TIP]
 ====
-Although much smaller, it might still take time for the testnet to fully sync. You can check if syncing was complete by running the following command in the geth intractive console:
+Although much smaller, it might still take time for the testnet to fully sync. You can check if syncing was complete by running the following command in the geth interactive console:
 ----
 eth.getBlock("latest").number
 ----
-This should return a number other than 0 once the your testnet node is fully in sync.
+This should return a number other than 0 once your testnet node is fully in sync. You can compare the number to the latest block in a known testnet block explorer, such as https://ropsten.etherscan.io/
 ====
 
-Similary, to connect to the Rinkeby network, use the command-line argument:
+Similarly, to connect to the Rinkeby network, use the command-line argument:
 ----
 geth --rinkeby
 ----

--- a/ethereum-testnets.asciidoc
+++ b/ethereum-testnets.asciidoc
@@ -23,7 +23,40 @@ Infura was born with the goal of delivering stable and reliable RPC access to th
 https://infura.io/docs/gettingStarted/chooseaNetwork
 
 ==== Geth
-//// TO DO: Loosely explain the geth commands to connect to a testnet
+Geth natively supports both the Ropsten and Rinkeby networks. To connect to the Ropsten network use the command-line argument:
+----
+geth --testnet
+----
+This will start syncing the Ropsten blockchain. A new directory named 'testnet' will be created in you main Ethereum data directory. A 'keystore' directory will be create inside 'testnet' and will store the private keys of you testnet accounts. As of writing this, the Ropsten blockchain is significantly smaller than the main Ethereum blockchain, and consists of about 14GB of data. Since the testnet requires less resouces, it is simpler to setup and test your code on the testnet first.
+
+
+Interacting with the tesnet is similar to the Mainnet. You can start geth testnet with a console, by running:
+----
+geth --testnet console
+----
+
+This makes it possible to perform operations such as opening a new account, checking you balance, checking the balance of other Ethereum addresses, etc.
+When running outside of the geth console, operations can be performed similarly to how they would have been performed on the Mainnet, simply by adding the --testnet parameter to the command-line instruction. As an example to list all the available testnet accounts and their addresses, run:
+----
+geth --testnet account list
+----
+
+More on setting up geth at: <<clients.asciidoc#Go-Ethereum,Go-Ethereum (Geth)>>
+
+[TIP]
+====
+Although much smaller, it might still take time for the testnet to fully sync. You can check if syncing was complete by running the following command in the geth intractive console:
+----
+eth.getBlock("latest").number
+----
+This should return a number other than 0 once the your testnet node is fully in sync.
+====
+
+Similary, to connect to the Rinkeby network, use the command-line argument:
+----
+geth --rinkeby
+----
+
 
 ==== Parity
 Connecting to a testnet in Parity requires using command-line arguments. For instance, to start Parity on the Ropsten testnet, run:


### PR DESCRIPTION
This adds some basic instruction to interacting with available testnets in geth