### PR TITLE
Dapps.asciidoc change replacing outdated tool.

### DIFF
--- a/dapps.asciidoc
+++ b/dapps.asciidoc
@@ -125,6 +125,7 @@ Dapp is a simple command line tool for smart contract development. It supports t
 * Source code building
 * Unit testing
 * Simple contract deployments
+
 Getting Started & Documentation; https://dapp.readthedocs.io/en/latest/
 
 === Populous

--- a/dapps.asciidoc
+++ b/dapps.asciidoc
@@ -118,6 +118,13 @@ Github link; https://github.com/embark-framework/embark
 
 Website link; https://github.com/embark-framework/embark
 
-=== Dapple
+=== Dapp (development tool)
+Dapp is a simple command line tool for smart contract development. It supports these common usecases:
+
+* Package management
+* Source code building
+* Unit testing
+* Simple contract deployments
+Getting Started & Documentation; https://dapp.readthedocs.io/en/latest/
 
 === Populous


### PR DESCRIPTION
replaced "Dapple" with "Dapp(development)" after finding out its an out-dated tool dis-continued and re-worked as "Dapp", also added information about the tool.