### PR TITLE
Update preface.asciidoc with Luke Schoen as contributor

### DIFF
--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -200,6 +200,7 @@ Following is an alphabetically sorted list of notable GitHub contributors, inclu
 * Jon Ramvi (ramvi)
 * Kevin Carter (kcar1)
 * Krzysztof Nowak (krzysztof)
+* Luke Schoen (ltfschoen)
 * Liang Ma (liangma)
 * Martin Berger (drmartinberger)
 * Matthew Sedaghatfar (sedaghatfar)


### PR DESCRIPTION
Propose to add Luke Schoen (ltfschoen) as contributor:
* 23 April 2018 - Offered addition of an Ethereum EVM Context diagram https://github.com/ethereumbook/ethereumbook/issues/496
 * 10 Mar - 14 Apr 2018 - See various Pull Requests that were offered https://github.com/ethereumbook/ethereumbook/commits?author=ltfschoen