### PR TITLE
Consensus chapter changes

### DIFF
--- a/consensus.asciidoc
+++ b/consensus.asciidoc
@@ -2,28 +2,48 @@
 
 == Consensus
 
-When it comes to decentralized record keeping, which is how blockchain technology is often described, it becomes infeasible to rely on trust alone to ensure that factual information is added to the record books. This problem arises in decentralized networks as a result of the lack of a central entity that would typically decide what should and should not be considered as fact. It's difficult to avoid this issue when working with blockchain technology because it is this lack of a central entity that is one of the main contributors to blockchain's popularity. In order to circumvent this issue a network must have a system in place by which a consensus can be reached by the nodes in the network.
-
-A consensus metric is a measurable datum on which a blockchain network's nodes must agree in order to establish and maintain consensus for the data contained in each block.  In blockchain technology, consensus metrics are measured and approved by each network node every time a new block is to be added to the chain. As a result of the consensus metric, blockchains act as chains of truth extended from one certainly verifiable fact to the next. Because of the consensus metric, protocol nodes can always tell a false copy of the blockchain from a true one. These measures are required in order to keep bad actors from frauding the network by submitting blocks containing false information. As a result, the integrity of the blockchain is not only established, but also maintained, over the long run. Consensus metrics take a variety of forms, but the two most important for this discussion are risk-based metrics and work-based metrics.
-
-=== Work-based metrics
-
-Also known as Proof-of-Work (POW), these metrics consist of a hard-to-compute hash that, when computed accurately serves as an attestation that a certain amount of computing power has been done. This is how work-based consensus metrics operate. Every node agrees on what should make up the metric:
-
-1. A certain hashing scheme (in the case of Bitcoin, SHA-256.)
-2. A certain set of data to be hashed (in the case of Bitcoin, the current timestamp, the previous block's hash, the merkle root, and the nonce.)
-3. A hash with the right number of leading zeroes that can be the proven output of the given four above inputs.
-
-Since a nonce is just an arbitrarily selected number, the nonce can be incremented as many times as necessary to output the right hash with the right number of leading zeroes. Since computing power is a scarce resource, this guarantees that all Bitcoin is "backed" in some amount of work. For many people, work-based consensus metrics are the only valid kind of consensus metrics that can make up a blockchain.
-
-Risk-based consensus metrics operate differently. Rather than agreeing that all  
+When it comes to decentralized record keeping, which is one important aspect of how blockchain technology functions, it becomes infeasible to rely on trust alone to ensure that factual information is added to the record books. This problem arises in decentralized networks as a result of the lack of a central entity that would typically decide what should and should not be considered as fact. It's difficult to avoid this issue when working with blockchain technology because it is this lack of a central entity that is one of the main contributors to blockchain's popularity. In order to circumvent this issue a network must have a system in place by which a consensus can be reached by the nodes in the network.
 
 
-Similarly when a correct hash is found, it's easy to prove to the rest of the network nodes because it can be shown to follow from the previous block (the previous block being the previous field of haystacks.)
+=== Consensus Metrics
+
+A consensus metric is a measurable datum on which a blockchain network's nodes must agree in order to establish and maintain consensus for the data contained in each block.  In blockchain technology, consensus metrics are measured and approved by each network node every time a new block is to be added to the chain. As a result of the consensus metric, blockchains act as chains of truth extended from one certainly verifiable fact to the next. Because of the consensus metric, a blockchain protocol's nodes become _mini-notaries_, instantly able to tell a false copy of the blockchain from the true one and report that fact to the entire network. These measures are required in order to keep bad actors from frauding the network by submitting blocks containing false information. As a result of the consensus metric of a blockchain the integrity of the blockchain is not only established, but also maintained, over the long run. Consensus metrics take a variety of forms, but the two most important for this discussion are risk-based metrics and work-based metrics.
+
+=== Hash-Based Metrics
+
+Commonly known as Proof-of-Work (PoW) metrics, these metrics establish consensus because protocols that use them set computers to work on finding difficult numbers. For the sake of illustration, consider supercomputers whose only job in life is to search integer-space for prime numbers. Now consider a whole network of average computers. These computers, when put together, might be said to have the combined power of a supercomputer. The only job for this network of computers is similarly to search possible numbers for another kind of number called a SHA-256 hash. These numbers have unique properties, just like prime numbers, that make them easily identifiable when discovered.  
+
+When SHA-256 hashes are computed accurately they serve as an attestation that a certain amount of computing power has been used to find the number. The most recent prime number to be found is asciimath:[2^(77,232,917) − 1]. It was found by a computer just like SHA-256 hashes are found by computers. SHA-256 hashes are easier to find than new prime numbers, however, and this is where hash-based metrics derive their power.
+
+Every SHA-256 hash has 64 hexadecimal characters in it. For example, here is the SHA-256 hash for the word "yank".
+`"yank"(SHA-256) = 45F1B9FC8FD5F760A2134289579DF920AA55830F2A23DCF50D34E16C1292D7E0`
+
+Compare this to the SHA-256 hash of the three letters "yan".
+
+`"yan"(SHA-256)  = 281ACA1A80B52620BD717E8B14A0386B8ADA92AE859AC2C8A2AC222EFA02EDBB` 
+
+Compare this alternately to the SHA-256 hash of the two letters "ya".
+
+`"ya"(SHA-256)   = 6663103A3E47EFC879EA31FA38458BE23BE0CE0895F3D8B27B7EA19A1120B3D4`
+
+Lastly, compare this to the SHA-256 hash of the single letter "y".
+
+`"y"(SHA-256)    = A1FCE4363854FF888CFF4B8E7875D600C2682390412A8CF79B37D0B11148B0FA`
+
+=== Validation for Hash-Based Metrics
+
+If you hash enough random phrases, kind of like monkeys on a typewriter, eventually you will find a hash that matches a certain pattern. In the case of the hash for "ya", note that it begins with the pattern "666". This is similar to Bitcoin, except Bitcoin requires that hashes be found matching the pattern beginning with "000". Any hash that can be created by plugging information from the previous block into the SHA-256 hashing algorithm can be used to create the next block, as long as it has the right amount of leading zeros in the number, the network will agree on it and the block reward will be yours.
+
+Since more and more people wish to mine Bitcoin every day, there is more computer power going to finding SHA-256 hashes, so the Bitcoin software automatically adjusts the difficulty of the consensus metric by requiring an increased amount of leading zeros to form consensus. This guarantees that new blocks are created in roughly the same increments of time as previous blocks. 
 
 
+== Risk-Based Metrics
 
-There are different types of consensus protocols in use in blockchain technologies, we will focus on proof of work (*POW*) and proof of stake (*POS*).
+Commonly known as Proof-of-Stake (PoS) metrics, these metrics establish consensus because everyone runs the same amount of risk if they fail to create correct blocks. Rather than demanding each node finds an arbitrary number to add a block, as with hash-based metrics, risk-based metrics only demand that some amount of money is at risk if the validator fails to create good blocks. The metric that all nodes agree upon here is whether or not another particular node has created a block in good faith. Rather than relying on hashing arbitrary numbers to make sure a certain amount of work has gone into creating a new block, risk-based chain nodes only need to agree that a certain amount has been staked and under what conditions that stake should be slashed.
+
+Risk-based chains depend upon quick, immediate, and irreversible repercussions to any block creators that fail to create what other nodes in the network consider to be quality blocks. By enforcing risk of resources lost, the process of hash-based metrics (which also relies on people not wanting to waste resources to work) can be shortcutted and implemented in a simpler way. Although fully risk-based blockchains are a topic for current research and have yet to be implemented in Ethereum, there is good reason to believe that the model will operate sufficiently when implemented properly in software.
+
+=== POW
 
 Proof of work is a consensus protocol that considers the valid blockchain in the network to be the chain that was most computationally expensive to create. The computational work that is referred to here is the work that had to be done to add all of the blocks to the current blockchain. This work is done by network nodes and must be computationally difficult, so as to make the work non-trivial, but must also be feasible, so as to be attainable after a reasonable amount of effort is exerted. Ultimately, the network will rely on nodes providing this POW in order to maintain the blockchain and is, therefore, in the best interest of the network to require a sensible POW.
 

--- a/consensus.asciidoc
+++ b/consensus.asciidoc
@@ -4,7 +4,26 @@
 
 When it comes to decentralized record keeping, which is how blockchain technology is often described, it becomes infeasible to rely on trust alone to ensure that factual information is added to the record books. This problem arises in decentralized networks as a result of the lack of a central entity that would typically decide what should and should not be considered as fact. It's difficult to avoid this issue when working with blockchain technology because it is this lack of a central entity that is one of the main contributors to blockchain's popularity. In order to circumvent this issue a network must have a system in place by which a consensus can be reached by the nodes in the network.
 
-A consensus protocol is a system that allows network nodes to reach an agreement on what should be considered as truth. When referring to a blockchain network this protocol is used to determine which copy of the blockchain is the true copy. This is required in order to prevent malicious parties from frauding the network and to guarantee the integrity of the blockchain is maintained. There are different types of consensus protocols in use in blockchain technologies, we will focus on proof of work (*POW*) and proof of stake (*POS*).
+A consensus metric is a measurable datum on which a blockchain network's nodes must agree in order to establish and maintain consensus for the data contained in each block.  In blockchain technology, consensus metrics are measured and approved by each network node every time a new block is to be added to the chain. As a result of the consensus metric, blockchains act as chains of truth extended from one certainly verifiable fact to the next. Because of the consensus metric, protocol nodes can always tell a false copy of the blockchain from a true one. These measures are required in order to keep bad actors from frauding the network by submitting blocks containing false information. As a result, the integrity of the blockchain is not only established, but also maintained, over the long run. Consensus metrics take a variety of forms, but the two most important for this discussion are risk-based metrics and work-based metrics.
+
+=== Work-based metrics
+
+Also known as Proof-of-Work (POW), these metrics consist of a hard-to-compute hash that, when computed accurately serves as an attestation that a certain amount of computing power has been done. This is how work-based consensus metrics operate. Every node agrees on what should make up the metric:
+
+1. A certain hashing scheme (in the case of Bitcoin, SHA-256.)
+2. A certain set of data to be hashed (in the case of Bitcoin, the current timestamp, the previous block's hash, the merkle root, and the nonce.)
+3. A hash with the right number of leading zeroes that can be the proven output of the given four above inputs.
+
+Since a nonce is just an arbitrarily selected number, the nonce can be incremented as many times as necessary to output the right hash with the right number of leading zeroes. Since computing power is a scarce resource, this guarantees that all Bitcoin is "backed" in some amount of work. For many people, work-based consensus metrics are the only valid kind of consensus metrics that can make up a blockchain.
+
+Risk-based consensus metrics operate differently. Rather than agreeing that all  
+
+
+Similarly when a correct hash is found, it's easy to prove to the rest of the network nodes because it can be shown to follow from the previous block (the previous block being the previous field of haystacks.)
+
+
+
+There are different types of consensus protocols in use in blockchain technologies, we will focus on proof of work (*POW*) and proof of stake (*POS*).
 
 Proof of work is a consensus protocol that considers the valid blockchain in the network to be the chain that was most computationally expensive to create. The computational work that is referred to here is the work that had to be done to add all of the blocks to the current blockchain. This work is done by network nodes and must be computationally difficult, so as to make the work non-trivial, but must also be feasible, so as to be attainable after a reasonable amount of effort is exerted. Ultimately, the network will rely on nodes providing this POW in order to maintain the blockchain and is, therefore, in the best interest of the network to require a sensible POW.
 


### PR DESCRIPTION
Added descriptions for _metrics_ (measuring points) around which PoS and PoW chains operate. Metrics can be either risk-based, or hash-bashed, (alternatively work-based.) The former metric relies on network nodes properly identifying and creating risk, while the latter metric relies on network nodes properly identifying and validating a certain scheme of hashes derived from public data. In both cases, the _risk_ or the _hash_ is the particular, identifiable, measuring factor (namely, the metric) by which **consensus** may be achieved on each particular chain.