### PR TITLE
 Edited wrong statement + improved details

### DIFF
--- a/keys-addresses.asciidoc
+++ b/keys-addresses.asciidoc
@@ -21,9 +21,9 @@ First, we will introduce cryptography and explain the mathematics used in Ethere
 [[pkc]]
 === Public key cryptography and cryptocurrency
 
-((("keys and addresses", "overview of", "public key cryptography")))((("digital currencies", "cryptocurrency")))Public key cryptography was invented in the 1970s and is a mathematical foundation for computer and information security.
+((("keys and addresses", "overview of", "public key cryptography")))((("digital currencies", "cryptocurrency")))Public key cryptography is a core concept of modern day information security. First publicly invented in the 1970s by Martin Hellman, Whitfield Diffie and Ralph Merkle, it was a monumental breakthrough which incited the first big wave of public interest into the field of cryptography. Before the 70s, strong cryptographic knowledge was held under governmental control with little public research untill the open publication of public key cryptography research.
 
-Most modern cryptography is based on mathematical functions that have a unique property: they are easy to calculate in one direction, but very difficult to calculate in the inverse direction. Based on these mathematical functions, cryptography enables the creation of digital secrets and unforgeable digital signatures.
+Public key cryptography uses unique keys that are used to secure information. These unique keys are based on mathematical functions that have a unique property: they are easy to calculate in one direction, but very difficult to calculate in the inverse direction. Based on these mathematical functions, cryptography enables the creation of digital secrets and unforgeable digital signatures which are secured by the laws of mathematics.
 
 For example, multiplying two large prime numbers together is trivial. But given the product of two large primes, it is very difficult to find the prime factors (a problem called _prime factorization_). Let's say I present the number 6895601 and tell you it is the product of two primes. Finding those two primes is much harder than it was for me to multiply them to produce 6895601.
 


### PR DESCRIPTION
- Edited wrong statement: "Public key cryptography was invented in the 1970s and is a mathematical foundation for computer and information security." ~ Public key cryptography is not a mathematical foundation, it is a foundation of cryptography and information security

- Added extra important detail on the history of public key cryptography (1-2 sentences mentioning how there was little public interest before the open source publication of public key cryptography by Martin Hellman, Whitfield Diffie and Ralph Merkle)