### PR TITLE
Expand EVM def with text from ch01

### DIFF
--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -38,6 +38,8 @@ Block::
 Blockchain::
 	A sequence of blocks validated by the proof-of-work system, each linking to its predecessor all the way to the genesis block. This varies from the Bitcoin protocol's in that it does not have a block size limit, it instead uses varying gas limits.
 
+Bytecode::
+
 Byzantium::
   Byzantium is the first of two hard forks for Metropolis development stage. It included EIP-649: Metropolis Difficulty Bomb Delay and Block Reward Reduction, where the Ice Age (see below) was delayed by 1 year, and the block reward was reduced from 5 to 3 ether.
 
@@ -104,11 +106,11 @@ Event::
     An event allows the use of EVM logging facilities, which in turn can be used to “call” JavaScript callbacks in the user interface of a DApp, which listen for these events. For more information, see http://solidity.readthedocs.io/en/develop/contracts.html#events
 
 EVM::
-    Ethereum Virtual Machine. The EVM has a simple stack-based architecture. In Ethereum, the execution model specifies how the system state is altered given a series of bytecode instructions and a small tuple of environmental data.
+    Ethereum Virtual Machine, a stack-based virtual machine which executes bytecode. In Ethereum, the execution model specifies how the system state is altered given a series of bytecode instructions and a small tuple of environmental data.
     This is specified through a formal model of a virtual state machine.
 
 EVM Assembly Language::
-    A human-readable form of EVM-code.
+    A human-readable form of EVM bytecode.
 
 Fallback function::
     It's like a fishing net to catch all the ether that is sent to a contract.


### PR DESCRIPTION
• Expand the EVM definition with slightly modified text from “Ethereum’s components” in ch01.
• The definition mentions bytecode, so note the need for a definition for it. 
• Expand “code” to “bytecode” in the subsequent definition.