### PR TITLE
Error in oraclize snippet

### DIFF
--- a/oracles.asciidoc
+++ b/oracles.asciidoc
@@ -124,7 +124,7 @@ contract ExampleOraclizeContract is usingOraclize {
     }
     
     function __callback(bytes32 myid, string result) public {
-        assert(msg.sender != oraclize_cbAddress());
+        assert(msg.sender == oraclize_cbAddress());
         id = myid;
         temperature = result;
         emit newTemperatureMeasurement(id, temperature);

--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -218,6 +218,7 @@ Following is an alphabetically sorted list of notable GitHub contributors, inclu
 * Joel Gugger (guggerjoel)
 * Jonathan Velando (rigzba21)
 * Jon Ramvi (ramvi)
+* Jules Lainé (fakje)
 * Kevin Carter (kcar1)
 * Krzysztof Nowak (krzysztof)
 * Luke Schoen (ltfschoen)


### PR DESCRIPTION
The oraclize query callback function should only be callable by oraclize. As-is in the code snippet, the function is callable by anyone but oraclize.