### PR TITLE
Remove potentially confusing word

### DIFF
--- a/what-is.asciidoc
+++ b/what-is.asciidoc
@@ -91,7 +91,7 @@ The four main development stages are codenamed Frontier, Homestead, Metropolis a
 [[past_transitions]]
 ==== Past transitions
 
-Block #0:: *"Frontier"* - The initial "test" stage of Ethereum, lasted from July 30th 2015 to March 2016.
+Block #0:: *"Frontier"* - The initial stage of Ethereum, lasted from July 30th 2015 to March 2016.
 
 Block #200,000:: "Ice Age" - A hard fork to introduce an exponential difficulty increase, motivating a transition to Proof-of-Stake.
 


### PR DESCRIPTION
To avoid confusion with the concept of "testnet. "