### PR TITLE
Fix 3 typos

### DIFF
--- a/smart-contracts.asciidoc
+++ b/smart-contracts.asciidoc
@@ -256,7 +256,7 @@ msg.sender:: We've already used this one. It represents the address that origina
 
 msg.value:: The value of ether sent with the message.
 
-msg.gas:: The amount of gas left in the message that called our contract. It has been deprecate and will be replaced with the gasleft() function as of Solidity v0.4.21.
+msg.gas:: The amount of gas left in the message that called our contract. It has been deprecated and will be replaced with the gasleft() function as of Solidity v0.4.21.
 
 msg.data:: The data payload of the message that called our contract.
 
@@ -318,7 +318,7 @@ Solidity's main data type is the _contract_ object, which is defined at the top 
 
 Solidity offers two other objects that are similar to a contract:
 
-interface:: An interface definition is structured exactly a contract, except none of the functions are defined, they are only declared. This type of function declaration is often called a _stub_, as it tells you about the arguments and return types of all the functions, without any implementation. It serves to specify a contract interface and if inherited, each of the functions must be specified in the child.
+interface:: An interface definition is structured exactly as a contract, except none of the functions are defined, they are only declared. This type of function declaration is often called a _stub_, as it tells you about the arguments and return types of all the functions, without any implementation. It serves to specify a contract interface and if inherited, each of the functions must be specified in the child.
 
 library:: A library contract is one that is meant to be deployed only once and used by other contracts, using the +delegatecall+ method (see <<solidity_address_object>>).
 
@@ -362,7 +362,7 @@ payable:: A payable function is one that can accept incoming payments. Functions
 
 As you can see in our +Faucet+ example, we have one payable function (the fallback function), which is the only function that can receive incoming payments.
 
-==== Contract constructor and selfdstruct
+==== Contract constructor and selfdestruct
 
 There is a special function that is only used once. When a contract is created, it also runs the _constructor function_ if one exists, to initialize the state of the contract. The constructor is run in the same transaction as the contract creation. The constructor function is optional. In fact, our +Faucet+ example has no constructor function.
 


### PR DESCRIPTION
deprecate -> deprecated
exactly a contract -> exactly as a contract
selfdstruct -> selfdestruct