### PR TITLE
Updated gas.asciidoc for minor typos

### DIFF
--- a/gas.asciidoc
+++ b/gas.asciidoc
@@ -5,7 +5,7 @@
 Add high-level introduction, from a transactional and network perspective. then move to transactional - what is gas (unit to measure computational resources?), who needs it - when and why, how do you know how much is needed, how do you get it, what if i have too much, what if i don't have enough. move to block level, how does this transaction fit overall in a block (prioritization), who decides size, who decides fixed gas, gas refund. Future of gas.
 ////
 
-**Gas** is Ethereum's unit for measuring how much computational work a program takes to perform an action or a set of actions. Every operation performed by a transaction or contract costs a certain number of gas; the number of gas required is related to the type and number of computational steps that are being executed. In contrast to Bitcoin transaction fees, which only take into account the size of a transaction in kilobytes (kB), Ethereum transaction fees must account for an arbitrary number of computational steps that can be performed by smart contract code. The higher the number of operations a program performs, the higher the cost to run it to completion.
+**Gas** is Ethereum's unit for measuring how much computational work a program takes to perform an action or a set of actions. Every operation performed by a transaction or contract costs a certain number of gas; the number of gas required is related to the type and number of computational steps that are being executed. In contrast to Bitcoin transaction fees, which only take into account the size of a transaction in kilobytes (KB), Ethereum transaction fees must account for an arbitrary number of computational steps that can be performed by smart contract code. The higher the number of operations a program performs, the higher the cost to run it to completion.
 
 Each operation requires a fixed amount of gas. Some examples from the Ethereum yellow paper:
 
@@ -13,7 +13,7 @@ Each operation requires a fixed amount of gas. Some examples from the Ethereum y
 * Calculating a Keccak256 hash costs 30 gas + 6 more gas for every 256 bits of data being hashed
 * Sending a transaction costs 21000 gas
 
-Gas is a crucial component of Ethereum and serves a dual role. One, as a layer of abstraction between the price of ethereum(with it's volatility) and the reward to miners for the work they do. And the other being defense against denial of service attacks. In order to prevent accidental or malicious infinite loops or other computational wastage in the network, the initiator of each transaction is required to set a limit to the amount they are willing to spend on gas. The gas system therefore disincentivizes attackers from sending spam transactions, as they must pay proportionately for the computational, bandwidth, and storage resources that they consume.
+Gas is a crucial component of Ethereum and serves a dual role. One, as a layer of abstraction between the price of ethereum (with it's volatility) and the reward to miners for the work they do. And the other being defense against denial of service attacks. In order to prevent accidental or malicious infinite loops or other computational wastage in the network, the initiator of each transaction is required to set a limit to the amount they are willing to spend on gas. The gas system therefore disincentivizes attackers from sending spam transactions, as they must pay proportionately for the computational, bandwidth, and storage resources that they consume.
 
 === Halting Problem
 
@@ -109,8 +109,8 @@ Miners on the network decide what the block gas limit is. Individuals who want t
 Ethereum encourages deleting storage variables by refunding up to half the amount of the gas cost.
 There are 2 operations in the EVM with negative gas:
 
-Clearing a contract is -24,000 (SELFDESTRUCT)
-Clearing storage is -15,000 (SSTORE[x] = 0)
+* Clearing a contract is -24,000 (SELFDESTRUCT)
+* Clearing storage is -15,000 (SSTORE[x] = 0)
 
 ==== GasToken
 


### PR DESCRIPTION
Minor typos and formatting change to gas refund section to use bullets for the two items which should be in a list.