### PR TITLE
Capitalize Bitcoin where appropriate in standards-eip-erc.asciidoc

### DIFF
--- a/standards-eip-erc.asciidoc
+++ b/standards-eip-erc.asciidoc
@@ -24,7 +24,7 @@ Additions to the ERCs are done through https://github.com/ethereum/EIPs[EIPs], E
 [[bips]]
 === Bitcoin Improvement Proposals (BIPs)
 
-==== Standards from bitcoin used in Ethereum
+==== Standards from Bitcoin used in Ethereum
 
 [[eip_table]]
 === Table of Most Important EIPs and ERCs


### PR DESCRIPTION
https://bitcoin.org/en/vocabulary#bitcoin

> Bitcoin - with capitalization, is used when describing the concept of Bitcoin, or the entire network itself. e.g. "I was learning about the Bitcoin protocol today."
> 
> bitcoin - without capitalization, is used to describe bitcoins as a unit of account. e.g. "I sent ten bitcoins today."; it is also often abbreviated BTC or XBT.