### PR TITLE
Tokens: Update ERC777 interface

### DIFF
--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -217,6 +217,7 @@ Following is an alphabetically sorted list of notable GitHub contributors, inclu
 * Franco Daniel Berdun (fMercury)
 * Hudson Jameson (Souptacular)
 * Ivan Molto (ivanmolto)
+* Jacques Dafflon (jacquesd)
 * Jason Hill (denifednu)
 * Javier Rojas (fjrojasgarcia)
 * Joel Gugger (guggerjoel)

--- a/tokens.asciidoc
+++ b/tokens.asciidoc
@@ -764,7 +764,6 @@ interface ERC777Token {
     function granularity() public constant returns (uint256);
     function balanceOf(address owner) public constant returns (uint256);
 
-    function send(address to, uint256 amount) public;
     function send(address to, uint256 amount, bytes userData) public;
 
     function authorizeOperator(address operator) public;


### PR DESCRIPTION
> We've update the ERC777 standard, so here it is. Thank you for your work!

Remove the overloading of the `send` function which is not part of the
standard.
(See the standard's update: https://github.com/ethereum/EIPs/pull/1118)