### PR TITLE
Updated glossary for PoW/PoS

### DIFF
--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -249,10 +249,10 @@ Paralysis Proof System::
 Parity::
   One of the most prominent interoperable implementations of the Ethereum client software.
 
-Proof-of-Stake::
-    Proof-of-Stake (PoS) is a method by which a cryptocurrency blockchain protocol aims to achieve distributed consensus. Proof-of-Stake asks users to prove ownership of a certain amount of cryptocurrency (their "stake" in the network) in order to be able to participate to the validation of transactions.
+Proof-of-Stake (PoS)::
+    Proof-of-Stake is a method by which a cryptocurrency blockchain protocol aims to achieve distributed consensus. Proof-of-Stake asks users to prove ownership of a certain amount of cryptocurrency (their "stake" in the network) in order to be able to participate to the validation of transactions.
 
-Proof-of-Work::
+Proof-of-Work (PoW)::
     A piece of data (the proof) that requires significant computation to find. In Ethereum, miners must find a numeric solution to the Ethash algorithm that meets a network-wide difficulty target.
 
 Receipt::


### PR DESCRIPTION
Updated the entries for Proof of Stake and Proof of Work to include their acronym. 
We should stick with the one way of capitalising the acronym. PoS and PoW