### PR TITLE
EVM - more languages that compile to EVM

### DIFF
--- a/evm.asciidoc
+++ b/evm.asciidoc
@@ -529,3 +529,7 @@ The JUMPI instruction is next, and it once again accepts the top two elements on
 [[evm_tools_references]]
 === EVM Tools References
 * [ByteCode To Opcode Disassembler](https://etherscan.io/opcode-tool) (Useful to check/debug if compilation ran with integrity and for reverse-engineering purposes if the source code wasn't published)
+
+=== Other languages compiled to EVM
+
+Solidity is not the only language that compile to EVM. We dedicate a separate chaper for Vyper. For even more languages check [this list](https://github.com/pirapira/awesome-ethereum-virtual-machine#programming-languages-that-compile-into-evm).


### PR DESCRIPTION
Not only Solidity. Vyper is already mentioned. 

Even more languages here: https://github.com/pirapira/awesome-ethereum-virtual-machine#programming-languages-that-compile-into-evm

Just like long list of languages that compile to JVM: https://en.wikipedia.org/wiki/List_of_JVM_languages