### PR TITLE
Typo in smart-contracts.asciidoc

### DIFF
--- a/smart-contracts.asciidoc
+++ b/smart-contracts.asciidoc
@@ -393,7 +393,7 @@ contract MEContract {
 
 So, to summarize, a contract's lifecycle starts with a creation transaction from an EOA or other contract. If there is a constructor, it is called from the same creation transaction and can initialize the state of the contract as it is being created.
 
-The other end of the contract's lifecycle is _contract destruction_. contracts are destroyed by a special EVM opcode called +SEFDESTRUCT+. It used to be name +SUICIDE+, but that name was deprecated due to the negative associations of the word. In Solidity, this opcode is exposed as a high level built-in function called +selfdestruct+, which takes one argument: the address to receive any balance remaining in the contract account. It looks like this:
+The other end of the contract's lifecycle is _contract destruction_. contracts are destroyed by a special EVM opcode called +SELFDESTRUCT+. It used to be name +SUICIDE+, but that name was deprecated due to the negative associations of the word. In Solidity, this opcode is exposed as a high level built-in function called +selfdestruct+, which takes one argument: the address to receive any balance remaining in the contract account. It looks like this:
 
 ----
 selfdestruct(address recipient);


### PR DESCRIPTION
Not an expert but seems like a typo: SELFDESTRUCT for SEFDESTRUCT.