### PR TITLE
Fixed typos in ethereum-testnets.asciidoc

### DIFF
--- a/ethereum-testnets.asciidoc
+++ b/ethereum-testnets.asciidoc
@@ -7,7 +7,7 @@ A test network (testnet for short) is used to simulate the behavior of the main 
 
 === Using Testnets
 
-You can either connect to publicly available test networks or spawn a private test network of your own. First, let's use a public testnet for easier setup. To use a public testnet requires some testnet ether and a connection to that network. For testnet ether, "faucets" are used, which distribute test ether slowly, "dripping" out small amount to anyone who asks. To connect to a testnet, you need an Ethereum client, either a full client such as geth, or a gateway to a full client, such as MetaMask.
+You can either connect to publicly available test networks or spawn a private test network of your own. First, let's use a public testnet for easier setup. To use a public testnet requires some testnet ether and a connection to that network. For testnet ether, "faucets" are used, which distribute test ether slowly, "dripping" out a small amount to anyone who asks. To connect to a testnet, you need an Ethereum client, either a full client such as geth, or a gateway to a full client, such as MetaMask.
 
 === Getting Test Ether
 
@@ -180,7 +180,7 @@ https://github.com/ethereum/guide/blob/master/poa.md
 TODO: write up pros and cons of both mechanisms
 
 Proof-of-Work is a protocol where mining (an expensive computer calculation) must be performed to create new blocks (trustless transactions) on the blockchain (distributed ledger).
-Disadvantages: Inefficient energy consumption. Centralized hashing power with concentrated mining farms instead of being truly distributedd. Massive amount of computing power required to mine new blocks and its impact on the environment.
+Disadvantages: Inefficient energy consumption. Centralized hashing power with concentrated mining farms instead of being truly distributed. Massive amount of computing power required to mine new blocks and its impact on the environment.
 
 Proof-of-Authority is a protocol that distributes the minting load only to authorized and trusted signers that may mint new blocks at their own discretion and at any time with a minting frequency. https://github.com/ethereum/EIPs/issues/225
 Advantages: Blockchain participants with the most identity at stake are selected by an algorithm for the right to validate blocks to deliver transactions.


### PR DESCRIPTION
"dripping" out small amount to anyone who asks -> "dripping" out a small amount to anyone who asks

distributedd -> distributed