### PR TITLE
Minor corrections in keys-addresses.asciidoc

### DIFF
--- a/keys-addresses.asciidoc
+++ b/keys-addresses.asciidoc
@@ -50,9 +50,9 @@ https://en.wikipedia.org/wiki/Discrete_logarithm
 Elliptic Curve Cryptography: https://en.wikipedia.org/wiki/Elliptic_curve_cryptography
 ====
 
-In Ethereum, we use public key cryptography to create a key pair that controls access to ether and allows us to authenticate to contracts. The key pair consists of a private key, a unique public key, and are considered a "pair" because the public key is derived from the private key. The public key is used to receive funds and the private key is used to create digital signatures to sign transactions to spend the funds. Digital signatures are also used to authenticate owners or users of contracts, as we will see in <<contract_authentication>>.
+In Ethereum, we use public key cryptography to create a key pair that controls access to ether and allows us to authenticate to contracts. The key pair consists of a private key and a unique public key, which are considered a "pair" because the public key is derived from the private key. The public key is used to receive funds and the private key is used to create digital signatures to sign transactions to spend the funds. Digital signatures are also used to authenticate owners or users of contracts, as we will see in <<contract_authentication>>.
 
-There is a mathematical relationship between the public and the private key that allows the private key to be used to generate signatures on messages. This signature can be validated against the public key without revealing the private key.
+There is a mathematical relationship between the public and the private key that allows the private key to be used to generate signatures on messages. These signatures can be validated against the public key without revealing the private key.
 
 When spending ether, the current owner presents her public key and a signature (different each time, but created from the same private key) in a transaction. Through the presentation of the public key and signature, everyone in the Ethereum system can independently verify and accept the transaction as valid, confirming that the person transferring the ether owned them at the time of the transfer.
 


### PR DESCRIPTION
The key pair consists of a private key, a unique public key, and are considered a "pair" because the public key is derived from the private key -> The key pair consists of a private key and a unique public key, which are considered a "pair" because the public key is derived from the private key.

... used to generate signatures on messages. **This signature** can be ... -> ... used to generate signatures on messages. **These signatures** can be ...