### PR TITLE
Changed .v.py to .vy

### DIFF
--- a/vyper.asciidoc
+++ b/vyper.asciidoc
@@ -158,11 +158,11 @@ Vyper has its own online code editor and compiler at the following URL < https:/
 Each Vyper contract is saved in a single file with the .v.py extension.
 Once installed Vyper can compile and provide bytecode by running the following command
 
-vyper ~/hello_world.v.py
+vyper ~/hello_world.vy
 
 The human readable ABI code (in JSON format) can be obtained by then running the following command
 
-vyper -f json ~/hello_world.v.py
+vyper -f json ~/hello_world.vy
 
 
 :revnumber: v1.1


### PR DESCRIPTION
Vyper now switched to use its own file extension ``.vy``.