### PR TITLE
Fixed typo in transactions.asciidoc

### DIFF
--- a/transactions.asciidoc
+++ b/transactions.asciidoc
@@ -305,7 +305,7 @@ Let's look at a simple example, drawn from our <<solidity_faucet_example>>. In +
 function withdraw(uint withdraw_amount) public {
 ----
 
-The _prototype_ of the withdraw function is defined as the string containing the name of the function, followed by the data type of each of its arguments enclosed in parenthesis and separated by a single comma. The function name is +withdraw+ and it takes a single argument that is a uint (which is an alias for uint256). So the prototype of +withdraw+ would be:
+The _prototype_ of the withdraw function is defined as the string containing the name of the function, followed by the data type of each of its arguments enclosed in parentheses and separated by a single comma. The function name is +withdraw+ and it takes a single argument that is a uint (which is an alias for uint256). So the prototype of +withdraw+ would be:
 
 ----
 withdraw(uint256)


### PR DESCRIPTION
enclosed in **parenthesis** -> enclosed in **parentheses**