### PR TITLE
Missing comma

### DIFF
--- a/smart-contracts.asciidoc
+++ b/smart-contracts.asciidoc
@@ -168,7 +168,7 @@ Contract JSON ABI
 [{"constant":false,"inputs":[{"name":"withdraw_amount","type":"uint256"}],"name":"withdraw","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"payable":true,"stateMutability":"payable","type":"fallback"}]
 ----
 
-As you can see, the compiler produces a JSON object describing the two functions that are defined by +Faucet.sol+. This JSON object can be used by any application that wants to access the +Faucet+ contract once it is deployed. Using the ABI, an application such as a wallet or DApp browser, can construct transactions that call the functions in +Faucet+, with the correct arguments and argument types. For example, a wallet would know that to call the function +withdraw+ it would have to provide a +uint256+ argument named +withdraw_amount+. The wallet could prompt the user to provide that value, then create a transaction that encodes it and executes the +withdraw+ function.
+As you can see, the compiler produces a JSON object describing the two functions that are defined by +Faucet.sol+. This JSON object can be used by any application that wants to access the +Faucet+ contract once it is deployed. Using the ABI, an application such as a wallet or DApp browser, can construct transactions that call the functions in +Faucet+, with the correct arguments and argument types. For example, a wallet would know that to call the function +withdraw+, it would have to provide a +uint256+ argument named +withdraw_amount+. The wallet could prompt the user to provide that value, then create a transaction that encodes it and executes the +withdraw+ function.
 
 All that is needed for an application to interact with a contract is an ABI and the address where the contract has been deployed.
 


### PR DESCRIPTION
For example, a wallet would know that to call the function +withdraw+```,``` it would have to provide a +uint256+ argument named +withdraw_amount+.