### PR TITLE
Fix typo in dev-tools.asciidoc

### DIFF
--- a/dev-tools.asciidoc
+++ b/dev-tools.asciidoc
@@ -347,7 +347,7 @@ StatusError: Transaction: 0xe147ae9e3610334ada8d863c9028c12bd0501be2d0cfd05865c1
 
 ==== Embark
 Embark is a framework built to allow developers to easily develop and deploy Decentralized Applications.
-Embark integrates with Ethereum, IPFS, whisper and Swarm to offer the following feutuers:
+Embark integrates with Ethereum, IPFS, whisper and Swarm to offer the following features:
 
  * Automatically deploy contracts and make them available in JS code.
  * Watch for changes and update contracts to redeploy if needed.


### PR DESCRIPTION
Change ethereum-tokens to Ethereum tokens to be more consistent with the rest of the book. 