### PR TITLE
Fix typo in standards-eip-erc.asciidoc

### DIFF
--- a/standards-eip-erc.asciidoc
+++ b/standards-eip-erc.asciidoc
@@ -17,7 +17,7 @@ image::images/eip_workflow.png["Ethereum Improvement Proposal Workflow"]
 
 [[ercs]]
 === Ethereum Request for Comments (ERCs)
-Request for Comments(RFC) is a method being used to introduce technical and organizational guidelines for the internet as they are proposed by the https://www.ietf.org[Internet Engineering Task Force]. ERCS include similar guidelines to setup standards for the Ethereum network. Developed and accepted by the ethereum developer community and a current list of them are available in a following section.
+Request for Comments(RFC) is a method being used to introduce technical and organizational guidelines for the internet as they are proposed by the https://www.ietf.org[Internet Engineering Task Force]. ERCS include similar guidelines to setup standards for the Ethereum network. Developed and accepted by the Ethereum developer community and a current list of them are available in a following section.
 
 Additions to the ERCs are done through https://github.com/ethereum/EIPs[EIPs], Ethereum Improvement Protocol, a homage to Bitcoin's own BIPs. EIPs are written by developers and submitted for peer review where it is evaluated on it's usefulness and it's ability to add to the usefulness of existing ERCs. If they are accepted, they are finalized to become part of the ERC standard.
 


### PR DESCRIPTION
Capitalize ethereum where appropriate.