### PR TITLE
Fix asciidoc syntax issues in forks-history.asciidoc

### DIFF
--- a/forks-history.asciidoc
+++ b/forks-history.asciidoc
@@ -97,7 +97,7 @@ For the most part (as of April 2018) the two networks remain highly compatible. 
 ==== Core Network Development
 Being open projects, most blockchain platforms ultimately have many users and contributors. However, the core network development (code that runs the network) is often done by discrete groups due to the expertise and knowledge required to develop this type of software. As such the code that these groups produce is very closely tied to the code that actually runs the network.
 
-[cols=2*, options=header]
+[cols=",",options="header",]
 |===
 |Ethereum
 |Ethereum Classic
@@ -114,7 +114,7 @@ One of the biggest material differences between Ethereum and Ethereum Classic is
 ==== Immutability
 Within the context of blockchains, immutability refers to the preservation of blockchain history.
 
-[cols=2*, options=header]
+[cols=",",options="header",]
 |===
 |Ethereum
 |Ethereum Classic
@@ -127,7 +127,7 @@ Within the context of blockchains, immutability refers to the preservation of bl
 ==== Community structure
 While blockchains aim to be decentralized much of the world around them is centralized. Ethereum and Ethereum Classic approach this reality in different ways.
 
-[cols=2*, options=header]
+[cols=",",options="header",]
 |===
 |Ethereum
 |Ethereum Classic


### PR DESCRIPTION
Fix asciidoc syntax issues in forks-history.asciidoc preventing asciidoc build.

