### PR TITLE
Fix asciidoc syntax issues in clients.asciidoc

### DIFF
--- a/clients.asciidoc
+++ b/clients.asciidoc
@@ -585,4 +585,4 @@ When you are running a Parity full node, it also provides a full wallet and DApp
 
 [bibliography]
 === References
-- [[[1]]] EIP-161: http://eips.ethereum.org/EIPS/eip-161
+- [[ref-1]]  EIP-161: http://eips.ethereum.org/EIPS/eip-161

--- a/clients.asciidoc
+++ b/clients.asciidoc
@@ -585,4 +585,4 @@ When you are running a Parity full node, it also provides a full wallet and DApp
 
 [bibliography]
 === References
-- [[ref-1]]  EIP-161: http://eips.ethereum.org/EIPS/eip-161
+- [[ref-1]] EIP-161: http://eips.ethereum.org/EIPS/eip-161


### PR DESCRIPTION
Fix asciidoc syntax issues in clients.asciidoc preventing asciidoc build.

