### PR TITLE
Delete broken link for Remix

### DIFF
--- a/ethereum-testnets.asciidoc
+++ b/ethereum-testnets.asciidoc
@@ -35,7 +35,7 @@ https://infura.io/
 ==== Remix Integrated Development Environment (IDE)
 Remix IDE may be used to deploy and interact with smart contracts on the mainnet and testnets including Ropsten, Rinkeby, and Kovan (Web3 Provider using an Infura address and an API key or via Injected Web3 to use the network chosen in MetaMask) and Ganache (Web3 Provider Endpoint http://localhost:8545)
 
-https://github.com/ethereum/remix/blob/master/docs/run_tab.rst
+https://github.com/ethereum/remix
 https://medium.com/swlh/deploy-smart-contracts-on-ropsten-testnet-through-ethereum-remix-233cd1494b4b
 
 ==== Geth


### PR DESCRIPTION
https://github.com/ethereum/remix/blob/master/docs/run_tab.rst gives a 404
Replace with https://github.com/ethereum/remix (the readme should be similar to what was run_tab?)