### PR TITLE
Fix maths display for markdown

### DIFF
--- a/keys-addresses.asciidoc
+++ b/keys-addresses.asciidoc
@@ -147,21 +147,11 @@ image::images/simple_elliptic_curve.png["ecc-curve"]
 
 Ethereum uses a specific elliptic curve and set of mathematical constants, as defined in a standard called +secp256k1+, established by the National Institute of Standards and Technology (NIST). The +secp256k1+ curve is defined by the following function, which produces an elliptic curve:
 
-[latexmath]
-++++
-\begin{equation}
-{y^2 = (x^3 + 7)}~\text{over}~(\mathbb{F}_p)
-\end{equation}
-++++
+y^2^ = x^3^ + 7
 
 or
 
-[latexmath]
-++++
-\begin{equation}
-{y^2 \mod p = (x^3 + 7) \mod p}
-\end{equation}
-++++
+y^2^/mod p = (x^3^ + 7)/mod p
 
 The _mod p_ (modulo prime number p) indicates that this curve is over a finite field of prime order _p_, also written as latexmath:[\( \mathbb{F}_p \)], where p = 2^256^ – 2^32^ – 2^9^ – 2^8^ – 2^7^ – 2^6^ – 2^4^ – 1, which is a very large prime number.
 


### PR DESCRIPTION
Fixed: 

[latexmath]
++++
\begin{equation}
{y^2 = (x^3 + 7)}~\text{over}~(\mathbb{F}_p)
\end{equation}
++++

To display properly with y^2^ = x^3^ + 7