### PR TITLE
Syntax suggestion: keep -> keeping

### DIFF
--- a/transactions.asciidoc
+++ b/transactions.asciidoc
@@ -102,7 +102,7 @@ web3.eth.getTransactionCount("0x9e713963a92c02317a681b9bb3065a8249de124f", "pend
 
 As you can see, the first transaction we sent increased the transaction count to 41, showing the pending transaction. But when we sent 3 more transactions in quick succession, the +getTransactionCount+ call didn't count them. It only counted one, even though you might expect there to be 3 pending in the mempool. If we wait a few seconds to allow for network communications to settle down, the +getTransactionCount+ call will return the expected number. But in the interim, while there are more than one transactions pending, it might not help us.
 
-When you build an application that constructs transactions, it cannot rely on +getTransactionCount+ for pending transactions. Only when pending and confirmed are equal (all outstanding transactions are confirmed) can you trust the output of +getTransactionCount+ to start your nonce counter. Thereafter, keep track of the nonce in your application until each transaction confirms.
+When you build an application that constructs transactions, it cannot rely on +getTransactionCount+ for pending transactions. Only when pending and confirmed are equal (all outstanding transactions are confirmed) can you trust the output of +getTransactionCount+ to start your nonce counter. Thereafter, keeping track of the nonce in your application until each transaction confirms.
 
 Parity's JSON RPC interface offers the +parity_nextNonce+ function, that returns the next nonce that should be used in a transaction. The +parity_nextNonce+ function counts nonces correctly, even if you construct several transactions in rapid succession, without confirming them.
 


### PR DESCRIPTION
"Thereafter, keep track of the nonce in your application until each transaction confirms." -> "Thereafter, keeping track..."