### PR TITLE
Fixed a reference to public networks in tokens.asciidoc

### DIFF
--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -257,6 +257,7 @@ Following is an alphabetically sorted list of all GitHub contributors, including
 * Masi Dawoud (mazewoods)
 * Matthew Sedaghatfar (sedaghatfar)
 * Michael Freeman (stefek99)
+* Miguel Baizan (mbaiigl)
 * Mike Pumphrey (bmmpxf)
 * Mobin Hosseini (iNDicat0r)
 * Nagesh Subrahmanyam (chainhead)

--- a/tokens.asciidoc
+++ b/tokens.asciidoc
@@ -280,7 +280,7 @@ Edit the +truffle.js+ or +truffle-config.js+ configuration file to set up your +
 
 https://github.com/ethereumbook/ethereumbook/blob/develop/code/truffle/METoken/truffle-config.js
 
-If you use the example +truffle-config.js+, remember to create a file +.env+ in the +METoken+ folder containing your test private keys for testing and deployment on public Ethereum test networks, such as Ganache or Kovan. You can export your test network private key from MetaMask.
+If you use the example +truffle-config.js+, remember to create a file +.env+ in the +METoken+ folder containing your test private keys for testing and deployment on public Ethereum test networks, such as Ropsten or Kovan. You can export your test network private key from MetaMask.
 
 After that your directory look like:
 


### PR DESCRIPTION
Ropsten instead of Ganache.