### PR TITLE
Fix Typo "RCP" in clients.asciidoc

### DIFF
--- a/clients.asciidoc
+++ b/clients.asciidoc
@@ -404,7 +404,7 @@ Ethereum clients offer an Application Programming Interface (API) and a set of R
 
 Usually, the RPC interface is offered over as an HTTP service on port +8545+. For security reasons it is restricted, by default, to only accept connections from localhost (the IP address of your own computer which is +127.0.0.1+).
 
-To access the JSON-RPC API, you can use a specialized library, written in the programming language of your choice, which provides "stub" function calls corresponding to each available RPC command. Or, you can manually construct HTTP requests and send/receive JSON encoded requests. You can even use a generic command-line HTTP client, like +curl+, to call the RCP interface. Let's try that. First, ensure that you have Geth configured and running, then switch to a new terminal window (e.g. with +<ctrl>\+<shift>\+n+ or +<ctrl>\+<shift>\+t++ in an existing terminal window):
+To access the JSON-RPC API, you can use a specialized library, written in the programming language of your choice, which provides "stub" function calls corresponding to each available RPC command. Or, you can manually construct HTTP requests and send/receive JSON encoded requests. You can even use a generic command-line HTTP client, like +curl+, to call the RPC interface. Let's try that. First, ensure that you have Geth configured and running, then switch to a new terminal window (e.g. with +<ctrl>\+<shift>\+n+ or +<ctrl>\+<shift>\+t++ in an existing terminal window):
 
 [[curl_web3]]
 .Using curl to call the web3_clientVersion function over JSON-RPC

--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -233,6 +233,7 @@ Following is an alphabetically sorted list of all GitHub contributors, including
 * Diego H. Gurpegui (diegogurpegui)
 * Dimitris Tsapakidis (dimitris-t)
 * Enrico Cambiaso (auino)
+* Ersin Bayraktar (ersinbyrktr)
 * Flash Sheridan (FlashSheridan)
 * Franco Daniel Berdun (fMercury)
 * Hon Lau (masterlook)


### PR DESCRIPTION
The only change I made was changing the typo "RCP" to "RPC" (Only 1 word). 