### PR TITLE
Fixing a hyperlink

### DIFF
--- a/vyper.asciidoc
+++ b/vyper.asciidoc
@@ -237,7 +237,7 @@ Decorators like `@private` `@public` `@constant` and `@payable` may be used at t
 
 +@payable+ decorator:: Only functions with the `@payable` decorator are allowed to transfer value.
 
-Vyper implements [the logic of decorators](https://github.com/ethereum/vyper/blob/master/vyper/signatures/function_signature.py#L93) explicitly. For example, the Vyper compilation process will fail if a function has both a `@payable` decorator and a `@constant` decorator. This makes sense because a function that transfers value has by definition updated the state, so cannot be `@constant`. Each Vyper function must be decorated with either `@public` or `@private` (but not both!).
+Vyper implements https://github.com/ethereum/vyper/blob/master/vyper/signatures/function_signature.py#L93[the logic of decorators] explicitly. For example, the Vyper compilation process will fail if a function has both a `@payable` decorator and a `@constant` decorator. This makes sense because a function that transfers value has by definition updated the state, so cannot be `@constant`. Each Vyper function must be decorated with either `@public` or `@private` (but not both!).
 
 [[online_code_editor_and_compiler_sec]]
 === Online code editor and compiler


### PR DESCRIPTION
Accidentally used md syntax instead of asciidoc.
Resolved now :-)