### PR TITLE
Update dapps.asciidoc

### DIFF
--- a/dapps.asciidoc
+++ b/dapps.asciidoc
@@ -209,7 +209,7 @@ When building a DApp, you have to decide if you want to make the smart contracts
 
 ==== Auction DApp: Front-end user interface
 
-Once the Auction DApp contracts are deployed, you can interact with them using your favorite JavaScript console and +web3.js+, or another web3 library. However, most users will need an easy-to-use interface. Our Auction DApp user interface is built using the Vue2/Vuetify JavaScript framework from Google.
+Once the Auction DApp contracts are deployed, you can interact with them using your favorite JavaScript console and +web3.js+, or another web3 library. However, most users will need an easy-to-use interface. Our Auction DApp user interface is built using the as Vue.js JavaScript framework and Vuetify library of UI components.
 
 You can find the user interface code in the +code/auction_dapp/frontend+ folder in the book's repository. The directory has the following structure and contents:
 


### PR DESCRIPTION
Tiny update about the frontend stack of the example auction DApp
 - Vue/Vuetify are not developed by Google
 - Vue and Vuetify are working together, as framework and library on top of it