### PR TITLE
use consistent ids throughout JSON-RPC example

### DIFF
--- a/clients.asciidoc
+++ b/clients.asciidoc
@@ -416,10 +416,10 @@ To access the JSON-RPC API, you can use a specialized library, written in the pr
 .Using curl to call the web3_clientVersion function over JSON-RPC
 ----
 $ curl -X POST -H "Content-Type: application/json" --data \
-'{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":1}' \
+'{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":4192}' \
 http://localhost:8545
 
-{"jsonrpc":"2.0","id":1,
+{"jsonrpc":"2.0","id":4192,
 "result":"Geth/v1.8.0-unstable-02aeb3d7/linux-amd64/go1.8.3"}
 ----
 


### PR DESCRIPTION
The example refers to the same RPC command throughout, referring back to the same commands verbatim, so it should have the same id throughout.