### PR TITLE
fix typo in Vyper section

### DIFF
--- a/smart-contracts-vyper.asciidoc
+++ b/smart-contracts-vyper.asciidoc
@@ -306,4 +306,4 @@ token: address(ERC20)
 
 === Conclusions
 
-Vyper is a powerful and interesting new contract-oriented programming languages. Its design is biased towards "correctness", at the expense of some flexibility. This may allow programmers to write better smart contracts and avoid certain pitfalls that cause serious vulnerabilities to arise. Next, we will look at smart contract security in more detail. Some of the nuances of Vyper design may become more apparent once you read about all the possible security problems that can arise in smart contracts.
+Vyper is a powerful and interesting new contract-oriented programming language. Its design is biased towards "correctness", at the expense of some flexibility. This may allow programmers to write better smart contracts and avoid certain pitfalls that cause serious vulnerabilities to arise. Next, we will look at smart contract security in more detail. Some of the nuances of Vyper design may become more apparent once you read about all the possible security problems that can arise in smart contracts.


### PR DESCRIPTION
"languages" should be "language".