### PR TITLE
Update the openzeppelin link to the latest release

### DIFF
--- a/tokens.asciidoc
+++ b/tokens.asciidoc
@@ -236,7 +236,7 @@ Consensys EIP20:: A simple and easy to read implementation of an ERC20-compatibl
 https://github.com/ConsenSys/Tokens/blob/master/contracts/eip20/EIP20.sol
 
 OpenZeppelin StandardToken:: This implementation is ERC20-compatible, with additional security precautions. It forms the basis of OpenZeppelin libraries implementing more complex ERC20-compatible tokens with fundraising caps, auctions, vesting schedules and other features. You can see the Solidity code for OpenZeppelin StandardToken here:
-https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/token/ERC20/ERC20.sol
+https://github.com/OpenZeppelin/openzeppelin-solidity/blob/v1.12.0/contracts/token/ERC20/StandardToken.sol
 
 [[METoken_example]]
 ==== Launching our own ERC20 token


### PR DESCRIPTION
Things in master are always changing a lot. Always use a tagged version. The latest as of today is v1.12.0