### PR TITLE
Update the openzeppelin docs link to point to home

### DIFF
--- a/appdx-dev-tools.asciidoc
+++ b/appdx-dev-tools.asciidoc
@@ -410,7 +410,7 @@ Github: https://github.com/OpenZeppelin/openzeppelin-solidity
 
 Website: https://openzeppelin.org/
 
-Documentation: https://openzeppelin.org/api/docs/open-zeppelin.html
+Documentation: https://openzeppelin.org/api/
 
 ==== zeppelin_os
 https://github.com/zeppelinos[zeppelin_os] is an open source, distributed platform of tools and services on top of the EVM


### PR DESCRIPTION
The specific initial pages is prone to change. Actually, right now home redirects to a page called getting started.