### PR TITLE
Remove analogy to LLVM VM

### DIFF
--- a/evm.asciidoc
+++ b/evm.asciidoc
@@ -1,7 +1,7 @@
 [[evm_chapter]]
 == The Ethereum Virtual Machine
 
-At the heart of the Ethereum protocol and operation is the Ethereum Virtual Machine, or EVM for short. As you might guess from the name, it is a computation engine, not hugely dissimilar to the virtual machines of Microsoft's .NET framework or LLVM, or interpreters of other byte-code–compiled programming languages, such as Java. In this chapter we take a detailed look at the EVM, including its instruction set, structure and operation within the context of Ethereum state updates.
+At the heart of the Ethereum protocol and operation is the Ethereum Virtual Machine, or EVM for short. As you might guess from the name, it is a computation engine, not hugely dissimilar to the virtual machines of Microsoft's .NET framework, or interpreters of other byte-code–compiled programming languages, such as Java. In this chapter we take a detailed look at the EVM, including its instruction set, structure and operation within the context of Ethereum state updates.
 
 [[evm_description]]
 === What is it?


### PR DESCRIPTION
Remove the analogy of the EVM to the LLVM VM; I tested the LLVM compiler and its relatives for years, and never executed a single instruction on its VM.  If you really want an Apple analogue to the EVM, I will point with pride to NewtonScript bytecode.