### PR TITLE
Appendix A: fixed open asciidoc brackets for "other_ethereum_forks" section 

### DIFF
--- a/appdx-forks-history.asciidoc
+++ b/appdx-forks-history.asciidoc
@@ -113,7 +113,7 @@ Being open projects, blockchain platforms often have many users and contributors
 |ETCDEV, IOHK, and volunteers.
 |===
 
-thereum_forks]]
+[[other_ethereum_forks]]
 === A timeline of notable Ethereum forks
 
 Ellaism is an Ethereum-based network, and intends to use exclusively Proof-of-Work to secure the blockchain. It has a zero pre-mine and has no mandatory developer fees, with all support and development donated freely by the community. Its developers believe this makes their coin one of the most honest pure Ethereum projects, and something that is uniquely interesting as a platform for serious developers, educators, and enthusiasts. Ellaism is a pure smart contract platform. Its goal is to create a smart contract platform that is both fair and trustworthy.

--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -259,6 +259,7 @@ Following is an alphabetically sorted list of all GitHub contributors, including
 * Luke Schoen (ltfschoen)
 * Liang Ma (liangma)
 * Marcelo Creimer (mcreimer)
+* Mark Zabala (zabaladev)
 * Martin Berger (drmartinberger)
 * Masi Dawoud (mazewoods)
 * Matthew Sedaghatfar (sedaghatfar)


### PR DESCRIPTION
Looks like a previous copy-paste edit truncated some of the asciidoc syntax formatting.