### PR TITLE
Update Casper Link

### DIFF
--- a/01what-is.asciidoc
+++ b/01what-is.asciidoc
@@ -158,8 +158,8 @@ https://github.com/ethereum/wiki/wiki/Patricia-Tree
 * Ethash PoW algorithm:
 https://github.com/ethereum/wiki/wiki/Ethash
 
-* Casper PoS v1 Implementation Guide:
-https://github.com/ethereum/research/wiki/Casper-Version-1-Implementation-Guide
+* Casper PoS v2.1 Implementation Guide:
+https://github.com/ethereum/research/wiki/Casper-Version-2.1-Implementation-Guide
 
 * Go-Ethereum (Geth) client:
 https://geth.ethereum.org/


### PR DESCRIPTION
Apparently the Casper v1 link has been removed and replaced with a v2.1 Implementation spec a couple of weeks ago. The v1 link no longer works.