### PR TITLE
fix: Change ETC wording to reflect it being original version

### DIFF
--- a/contrib/etc-history.asciidoc
+++ b/contrib/etc-history.asciidoc
@@ -4,7 +4,7 @@ Ethereum (ETH) is a blockchain based system inspired by Bitcoin but built from t
 
     “Ethereum is a  decentralized platform that runs smart contracts: applications that run exactly as programmed without any possibility of downtime, censorship, fraud or third party interference.”
 
-Ethereum Classic (ETC) is a forked version of Ethereum that was activated around July 20th 2016, or more specifically block 1920000, when a controversial fork went through to prevent access to stolen funds from a project known as The DAO.  To quote the Ethereum Classic website:
+Ethereum Classic (ETC) is the original version of Ethereum that was branded around July 20th 2016, or more specifically block 1920000, when a controversial fork went through to prevent access to stolen funds from a project known as The DAO. Ethereum (ETH) is the forked version of the original chain after the DAO hardfork. To quote the Ethereum Classic website:
 
     “Ethereum Classic is a decentralized platform that runs smart contracts: applications that run exactly as programmed without any possibility of downtime, censorship, fraud or third party interference.
 


### PR DESCRIPTION
The wording about ETC in the `contrib` directory were inaccurate. ETC historically is the original chain, not a forked chain.