### PR TITLE
[nit] Fix typo for gwei representation

### DIFF
--- a/03clients.asciidoc
+++ b/03clients.asciidoc
@@ -468,7 +468,7 @@ $ <strong>curl -X POST -H "Content-Type: application/json" --data \
 </pre>
 ++++
 
-The response, +0x430e23400+, tells us that the current gas price is 1.8 gwei (gigawei or billion wei). If, like us, you don't think in hexadecimal, you can convert it to decimal on the command line with a little bash-fu:
+The response, +0x430e23400+, tells us that the current gas price is 18 gwei (gigawei or billion wei). If, like us, you don't think in hexadecimal, you can convert it to decimal on the command line with a little bash-fu:
 
 ++++
 <pre data-type="programlisting">


### PR DESCRIPTION
Issue here: https://github.com/ethereumbook/ethereumbook/issues/834

18000000000 wei should be 18 gwei instead of 1.8 gwei