### PR TITLE
smart-contracts-vyper: add infinite loop section

### DIFF
--- a/08smart-contracts-vyper.asciidoc
+++ b/08smart-contracts-vyper.asciidoc
@@ -184,6 +184,17 @@ As you can see, the conversion process ensures that no information can be lost; 
 
 Choosing explicit over implicit typecasting means that the developer is responsible for performing all casts. While this approach does produce more verbose code, it also improves the safety and auditability of smart contracts.
 
+==== Infinite Loop
+((("infinite loop")))((("Solidity","infinite loop")))((("Vyper","infinite loop")))Although there is no merit because of gaslimit, developers can write an endless loop processing in Solidity. Infinite loop makes it impossible to set an upper bound on gas limits, opening the door for gas limit attacks. Therefore, Vyper doesn't permit you to write the processing and has the following three features:
+
+The while statement::
+you can use while statement in Solidity, but Vyper doesn't have the statement.
+
+Deterministic number of iterations of for statement::
+Vyper has a for statement, but the upper limit of the number of iterations must be determinate, and `range ()` can only accept integer literals.
+
+Recursive calling::
+Recursive calling can be written in Solidity, but not in Vyper.
 
 ==== Preconditions and Postconditions
 

--- a/08smart-contracts-vyper.asciidoc
+++ b/08smart-contracts-vyper.asciidoc
@@ -187,11 +187,11 @@ Choosing explicit over implicit typecasting means that the developer is responsi
 ==== Infinite Loop
 ((("infinite loop")))((("Solidity","infinite loop")))((("Vyper","infinite loop")))Although there is no merit because of gaslimit, developers can write an endless loop processing in Solidity. Infinite loop makes it impossible to set an upper bound on gas limits, opening the door for gas limit attacks. Therefore, Vyper doesn't permit you to write the processing and has the following three features:
 
-The while statement::
-you can use while statement in Solidity, but Vyper doesn't have the statement.
+The `while` statement::
+you can use `while` statement in Solidity, but Vyper doesn't have the statement.
 
-Deterministic number of iterations of for statement::
-Vyper has a for statement, but the upper limit of the number of iterations must be determinate, and `range ()` can only accept integer literals.
+Deterministic number of iterations of `for` statement::
+Vyper has a `for` statement, but the upper limit of the number of iterations must be determinate, and `range ()` can only accept integer literals.
 
 Recursive calling::
 Recursive calling can be written in Solidity, but not in Vyper.


### PR DESCRIPTION
I very appreciate this book's authors. It's very useful for me.


[Vyper documentation](https://vyper.readthedocs.io/en/latest/) refers to Infinite-length loops and recursive calling as a feature of Vyper.

I propose to add a description of the difference between Solidity and Vyper on infinite loop to the `Comparison to Solidity` section.