### PR TITLE
Update 07smart-contracts-solidity.asciidoc

### DIFF
--- a/07smart-contracts-solidity.asciidoc
+++ b/07smart-contracts-solidity.asciidoc
@@ -338,7 +338,7 @@ Other functions worth noting are:
 
 +ecrecover+:: Recovers the address used to sign a message from the signature.
 
-++selfdestrunct(__recipient_address__)++:: Deletes the current contract, sending any remaining ether in the account to the recipient address.
+++selfdestruct(__recipient_address__)++:: Deletes the current contract, sending any remaining ether in the account to the recipient address.
 
 +this+:: The address of the currently executing contract account.(((range="endofrange", startref="ix_07smart-contracts-solidity-asciidoc12")))
 


### PR DESCRIPTION
Hi, 

thats my first time submitting a pull request so I hope im not screwing this up but: 

I found a small typo in a comand (selfdestrunct -> selfdestruct) not sure if this falls under "an error a non-domain-expert copy editor might miss" just wanted to let you know. It bothered me while reading this excellent work. Keep up the good work!