### PR TITLE
Small bug - found selfdestrunct (with an n)

### DIFF
--- a/07smart-contracts-solidity.asciidoc
+++ b/07smart-contracts-solidity.asciidoc
@@ -338,7 +338,7 @@ Other functions worth noting are:
 
 +ecrecover+:: Recovers the address used to sign a message from the signature.
 
-++selfdestrunct(__recipient_address__)++:: Deletes the current contract, sending any remaining ether in the account to the recipient address.
+++selfdestruct(__recipient_address__)++:: Deletes the current contract, sending any remaining ether in the account to the recipient address.
 
 +this+:: The address of the currently executing contract account.(((range="endofrange", startref="ix_07smart-contracts-solidity-asciidoc12")))
 


### PR DESCRIPTION
Changing selfdestrunct(__recipient_address__) to selfdestruct(__recipient_address__) 
Removing the letter n from the selfdestruct function call on line 341