### PR TITLE
Fix typo in openzeppelin import

### DIFF
--- a/code/truffle/METoken/contracts/METoken.sol
+++ b/code/truffle/METoken/contracts/METoken.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.21;
 
-import 'zeppelin-solidity/contracts/token/ERC20/StandardToken.sol';
+import 'openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol';
 
 contract METoken is StandardToken {
     string public constant name = 'Mastering Ethereum Token';

--- a/code/truffle/METoken_Faucet/contracts/METoken.sol
+++ b/code/truffle/METoken_Faucet/contracts/METoken.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.18;
 
-import 'zeppelin-solidity/contracts/token/ERC20/StandardToken.sol';
+import 'openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol';
 
 contract METoken is StandardToken {
     string public constant name = 'Mastering Ethereum Token';

--- a/code/truffle/METoken_METFaucet/contracts/METFaucet.sol
+++ b/code/truffle/METoken_METFaucet/contracts/METFaucet.sol
@@ -1,7 +1,7 @@
 // Version of Solidity compiler this program was written for
 pragma solidity ^0.4.19;
 
-import 'zeppelin-solidity/contracts/token/ERC20/StandardToken.sol';
+import 'openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol';
 
 
 // A faucet for ERC20 token MET

--- a/code/truffle/METoken_METFaucet/contracts/METoken.sol
+++ b/code/truffle/METoken_METFaucet/contracts/METoken.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.18;
 
-import 'zeppelin-solidity/contracts/token/ERC20/StandardToken.sol';
+import 'openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol';
 
 contract METoken is StandardToken {
     string public constant name = 'Mastering Ethereum Token';


### PR DESCRIPTION
## Problem
Running `truffle compile` on this contract results in the following error:

```Error: Could not find zeppelin-solidity/contracts/token/ERC20/StandardToken.sol from any sources;```

## Solution
The full name of the library is `openzeppelin-solidity`, not `zeppelin-solidity`.  Update import to use the correct library name.