### PR TITLE
ch02: faucet: replace `public` kw with `external`

### DIFF
--- a/code/Solidity/Faucet.sol
+++ b/code/Solidity/Faucet.sol
@@ -12,6 +12,5 @@ contract Faucet {
     }
 
     // Accept any incoming amount
-    function () public payable {}
-
+    function () external payable {}
 }


### PR DESCRIPTION
New to solidity, but when trying to compile the first example, I hit this error:

```
$ solc faucet.sol
faucet.sol:15:5: Error: Fallback function must be defined as "external".
    function() public payable { }
    ^---------------------------^
```

Seems like this changed in v0.5.0?


Not critical, but I also get this warning as well that I think would be good to quiet without the version pragma:

```
faucet.sol:4:1: Warning: Source file does not specify required compiler version! Consider adding "pragma solidity ^0.5.4;"
```