### PR TITLE
Online Vyper compilers

### DIFF
--- a/08smart-contracts-vyper.asciidoc
+++ b/08smart-contracts-vyper.asciidoc
@@ -270,7 +270,7 @@ This shows the correct ordering of functions and variables in a Vyper smart cont
 
 [[online_code_editor_and_compiler_sec]]
 === Compilation
-((("compiling","Vyper")))((("Vyper","compilation")))Vyper has its own https://vyper.online[online code editor and compiler], which allows you to write and then compile your smart contracts into bytecode, ABI, and LLL using only your web browser. The Vyper online compiler has a variety of prewritten smart contracts for your convenience, including contracts for a simple open auction, safe remote purchases, ERC20 tokens, and more.
+((("compiling","Vyper")))((("Vyper","compilation")))Vyper has its own https://vyper.online[online code editor and compiler], which allows you to write and then compile your smart contracts into bytecode, ABI, and LLL using only your web browser. The Vyper online compiler has a variety of prewritten smart contracts for your convenience, including contracts for a simple open auction, safe remote purchases, ERC20 tokens, and more. This tool, offers only one version of the compilation software. It is updated regularly but does not always guarantee the latest version. Etherscan has an https://etherscan.io/vyper[online Vyper compiler] which allows you to select the compiler version. Also https://remix.ethereum.org[Remix], originally designed for Solidity smart contracts, now has a Vyper plugin available in the settings tab.
 
 [NOTE]
 ====


### PR DESCRIPTION
There has been some discussion in the community about finding consistent compiler versions online. I learned that there are now actually 3 different online compilers (with different features) available.
I felt that this was important to put in ASAP because having to install the Vyper compiler from source is evidently hindering new adoption of Vyper.