### PR TITLE
Update 07smart-contracts-solidity.asciidoc

### DIFF
--- a/07smart-contracts-solidity.asciidoc
+++ b/07smart-contracts-solidity.asciidoc
@@ -338,7 +338,7 @@ Other functions worth noting are:
 
 +ecrecover+:: Recovers the address used to sign a message from the signature.
 
-++selfdestrunct(__recipient_address__)++:: Deletes the current contract, sending any remaining ether in the account to the recipient address.
+++selfdestruct(__recipient_address__)++:: Deletes the current contract, sending any remaining ether in the account to the recipient address.
 
 +this+:: The address of the currently executing contract account.(((range="endofrange", startref="ix_07smart-contracts-solidity-asciidoc12")))
 


### PR DESCRIPTION
- Fixes typo ('selfdestrunct' -> 'selfdestruct') on line 341
- Re: "Please submit only PRs for errors that a non-domain-expert copy editor might miss. Do not submit PRs for typos, grammar and syntax, as those are part of the copy editors job." A non-domain-expert copy editor may not know that 'selfdestrunct' is not a valid command.
- Likewise for an ESL reader, it may present a significant risk, as it may render a contract immortal (if say a crafty but novice programmer somehow manages to get it to compile anyway), obviously outside of intention if it is present.