### PR TITLE
Fix typo `tx.orgin`

### DIFF
--- a/07smart-contracts-solidity.asciidoc
+++ b/07smart-contracts-solidity.asciidoc
@@ -475,7 +475,7 @@ function destroy() public {
 }
 ----
 
-If anyone calls this +destroy+ function from an address other than +owner+, it will fail. But if the same address stored in +owner+ by the constructor calls it, the contract will self-destruct and send any remaining balance to the +owner+ address. Note that we did not use the unsafe +tx.origin+ to determine whether the owner wished to destroy the contract&#x2014;using +tx.orgin+ would allow malign contracts to destroy your contract without your permission.
+If anyone calls this +destroy+ function from an address other than +owner+, it will fail. But if the same address stored in +owner+ by the constructor calls it, the contract will self-destruct and send any remaining balance to the +owner+ address. Note that we did not use the unsafe +tx.origin+ to determine whether the owner wished to destroy the contract&#x2014;using +tx.origin+ would allow malign contracts to destroy your contract without your permission.
 
 ==== Function Modifiers
 


### PR DESCRIPTION
It should be `tx.origin`