### PR TITLE
Example should be int not uint

### DIFF
--- a/09smart-contracts-security.asciidoc
+++ b/09smart-contracts-security.asciidoc
@@ -291,7 +291,7 @@ the largest number, i.e., 999999, is surpassed) and periodic mathematical functi
 clarity, adding `257` to a `uint8` that currently has a value of `0` will result
 in the number `1`.  It is sometimes instructive to think of fixed-size variables
 as being cyclic, where we start again from zero if we add numbers above the
-largest possible stored number, and start counting down from the largest number if we subtract from zero. In the case of signed `int` types, which _can_ represent negative numbers, we start again once we reach the largest negative value; for example, if we try to subtract `1` from a `uint8` whose value is `-128`, we will get `127`.
+largest possible stored number, and start counting down from the largest number if we subtract from zero. In the case of signed `int` types, which _can_ represent negative numbers, we start again once we reach the largest negative value; for example, if we try to subtract `1` from a `int8` whose value is `-128`, we will get `127`.
 
 These kinds of numerical gotchas allow attackers to misuse code and create
 unexpected logic flows. For example, consider the +TimeLock+ contract in


### PR DESCRIPTION
In the example it "we try to subtract `1` from a `uint8` whose value is `-128`, we will get `127`."

You cant have a uint with a value of -128 it would have had to have been a signed integer(int)