### PR TITLE
grammatical error --  09smart-contracts-security.asciidoc

### DIFF
--- a/09smart-contracts-security.asciidoc
+++ b/09smart-contracts-security.asciidoc
@@ -2125,7 +2125,7 @@ Time-sensitive logic is sometimes required; e.g., for unlocking contracts
 dates. It is sometimes recommended to use http://bit.ly/2OdUC9C[`block.number`] and an average block time to estimate times; with
 a `10 second` block time, `1 week` equates to approximately, `60480 blocks`.
 Thus, specifying a block number at which to change a contract state can
-be more secure, as miners are unable easily to manipulate the block number. The
+be more secure, as miners are unable to easily manipulate the block number. The
 http://bit.ly/2AAebFr[BAT
 ICO] contract employed this strategy.
 


### PR DESCRIPTION
I thought this word ordering was a bit odd after reading this section. 
How about flipping the position of "to"?