### PR TITLE
Fix broken link

### DIFF
--- a/01what-is.asciidoc
+++ b/01what-is.asciidoc
@@ -151,7 +151,7 @@ http://bit.ly/2quAlTE
 http://bit.ly/2PmtjiS
 
 * LevelDB database (used most often to store the local copy of the blockchain):
-http://leveldb.org
+https://github.com/google/leveldb
 
 * Merkle Patricia trees:
 https://github.com/ethereum/wiki/wiki/Patricia-Tree


### PR DESCRIPTION
http://leveldb.org/ gives a 404
Point to LevelDB's GitHub repo instead