### PR TITLE
Fixed seed length in 05wallets.asciidoc to 256-bit from 512

### DIFF
--- a/05wallets.asciidoc
+++ b/05wallets.asciidoc
@@ -206,7 +206,7 @@ The process described in steps 7 through 9 continues from the process described 
 [start=7]
 7. The first parameter to the PBKDF2 key-stretching function is the _mnemonic_ produced in step 6.
 8. The second parameter to the PBKDF2 key-stretching function is a _salt_. The salt is composed of the string constant +"mnemonic"+ concatenated with an optional user-supplied passphrase.
-9. PBKDF2 stretches the mnemonic and salt parameters using 2,048 rounds of hashing with the HMAC-SHA512 algorithm, producing a 512-bit value as its final output. That 512-bit value is the seed.
+9. PBKDF2 stretches the mnemonic and salt parameters using 2,048 rounds of hashing with the HMAC-SHA512 algorithm, producing a 512-bit value as its final output. First 256-bit of that 512-bit value is the seed.
 
 <<mnemonic_to_seed_figure>> shows how a mnemonic is used to generate a seed.
 
@@ -216,7 +216,7 @@ image::images/bip39-part2.png["From mnemonic to seed"]
 
 [NOTE]
 ====
-The key-stretching function, with its 2,048 rounds of hashing, is a somewhat effective protection against brute-force attacks against the mnemonic or the passphrase. It makes it costly (in computation) to try more than a few thousand passphrase and mnemonic combinations, while the number of possible derived seeds is vast (2^512^, or about 10^154^)&#x2014;far bigger than the number of atoms in the visible universe (about 10^80^).
+The key-stretching function, with its 2,048 rounds of hashing, is a somewhat effective protection against brute-force attacks against the mnemonic or the passphrase. It makes it costly (in computation) to try more than a few thousand passphrase and mnemonic combinations, while the number of possible derived seeds is vast (2^256^, or about 10^77^)&#x2014;almost as big as the number of atoms in the visible universe (about 10^80^).
 ====
 
 Tables pass:[<a data-type="xref" data-xrefstyle="select:labelnumber" href="#mnemonic_128_no_pass">#mnemonic_128_no_pass</a>, <a data-type="xref" data-xrefstyle="select:labelnumber" href="#mnemonic_128_w_pass">#mnemonic_128_w_pass</a>, and <a data-type="xref" data-xrefstyle="select:labelnumber" href="#mnemonic_256_no_pass">#mnemonic_256_no_pass</a>] show some examples of mnemonic codes and the seeds they produce.


### PR DESCRIPTION
The mnemonic to seed section mentions the 512-bit output as seed, whereas the seed is first 256-bit of that output.