### PR TITLE
Update Parity dependencies and installation. 

### DIFF
--- a/03clients.asciidoc
+++ b/03clients.asciidoc
@@ -249,15 +249,16 @@ Try and run +parity+ to see if it is installed, by invoking the +--version+ opti
 ++++
 <pre data-type="programlisting">
 $ <strong>parity --version</strong>
-Parity
-  version Parity/v1.7.0-unstable-02edc95-20170623/x86_64-linux-gnu/rustc1.18.0
-Copyright 2015, 2016, 2017 Parity Technologies (UK) Ltd
-License GPLv3+: GNU GPL version 3 or later &lt;http://gnu.org/licenses/gpl.html&gt;.
+Parity Ethereum Client.
+  version Parity-Ethereum/v2.7.0-unstable-b69a33b3a-20200124/x86_64-unknown-linux-gnu/rustc1.40.0
+Copyright 2015-2020 Parity Technologies (UK) Ltd.
+License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
 This is free software: you are free to change and redistribute it.
 There is NO WARRANTY, to the extent permitted by law.
 
-By Wood/Paronyan/Kotewicz/Drwięga/Volf
-   Habermeier/Czaban/Greeff/Gotchac/Redmann
+By Wood/Paronyan/Kotewicz/Drwięga/Volf/Greeff
+   Habermeier/Czaban/Gotchac/Redman/Nikolsky
+   Schoedon/Tang/Adolfsson/Silva/Palm/Hirsz et al.
 $
 </pre>
 ++++

--- a/03clients.asciidoc
+++ b/03clients.asciidoc
@@ -219,7 +219,7 @@ Then change to the _parity_ directory and use +cargo+ to build the executable:
 ++++
 <pre data-type="programlisting">
 $ <strong>cd parity</strong>
-$ <strong>cargo install</strong>
+$ <strong>cargo install --path .</strong>
 </pre>
 ++++
 
@@ -227,19 +227,18 @@ If all goes well, you should see something like:
 
 ++++
 <pre data-type="programlisting">
-$ <strong>cargo install</strong>
-    Updating git repository `https://github.com/paritytech/js-precompiled.git`
- Downloading log v0.3.7
- Downloading isatty v0.1.1
- Downloading regex v0.2.1
+$ <strong>cargo install --path .</strong>
+Installing parity-ethereum v2.7.0 (/root/parity)
+Updating crates.io index
+Updating git repository `https://github.com/paritytech/rust-ctrlc.git`
+Updating git repository `https://github.com/paritytech/app-dirs-rs`   Updating git repository 
 
  [...]
 
-Compiling parity-ipfs-api v1.7.0
-Compiling parity-rpc v1.7.0
-Compiling parity-rpc-client v1.4.0
-Compiling rpc-cli v1.4.0 (file:///home/aantonop/Dev/parity/rpc_cli)
-Finished dev [unoptimized + debuginfo] target(s) in 479.12 secs
+Compiling parity-ethereum v2.7.0 (/root/parity)
+Finished release [optimized] target(s) in 10m 16s
+Installing /root/.cargo/bin/parity
+Installed package `parity-ethereum v2.7.0 (/root/parity)` (executable `parity`)
 $
 </pre>
 ++++

--- a/03clients.asciidoc
+++ b/03clients.asciidoc
@@ -181,7 +181,7 @@ Parity requires Rust version 1.27 or greater.
 
 ++++
 <pre data-type="programlisting">
-$ <strong>sudo apt-get install openssl libssl-dev libudev-dev cmake</strong>
+$ <strong>sudo apt-get install openssl libssl-dev libudev-dev cmake clang</strong>
 </pre>
 ++++
 


### PR DESCRIPTION
added clang dependency for parity
updated cargo install to cargo install --path= .
updated commandline outputs to reflect new commands and new version of parity