### PR TITLE
style: lint truffle's CallExamples contracts

### DIFF
--- a/code/truffle/CallExamples/contracts/CallExamples.sol
+++ b/code/truffle/CallExamples/contracts/CallExamples.sol
@@ -1,34 +1,37 @@
 pragma solidity ^0.4.22;
 
-contract calledContract {
-	event callEvent(address sender, address origin, address from);
-	function calledFunction() public {
-		emit callEvent(msg.sender, tx.origin, this);
-	}
+library CalledLibrary {
+    event CallEvent(address sender, address origin,  address from);
+    
+    function calledFunction() public {
+        emit CallEvent(msg.sender, tx.origin, this);
+    }
 }
 
-library calledLibrary {
-	event callEvent(address sender, address origin,  address from);
-	function calledFunction() public {
-		emit callEvent(msg.sender, tx.origin, this);
-	}
+
+contract CalledContract {
+    event CallEvent(address sender, address origin, address from);
+    
+    function calledFunction() public {
+        emit CallEvent(msg.sender, tx.origin, this);
+    }
 }
 
-contract caller {
 
-	function make_calls(calledContract _calledContract) public {
+contract Caller {
+    function make_calls(CalledContract _calledContract) public {
+        // Calling calledContract and calledLibrary directly
+        _calledContract.calledFunction();
 
-		// Calling calledContract and calledLibrary directly
-		_calledContract.calledFunction();
-		calledLibrary.calledFunction();
+        CalledLibrary.calledFunction();
 
-		// Low-level calls using the address object for calledContract
-		require(address(_calledContract).
-		        call(bytes4(keccak256("calledFunction()"))));
-		require(address(_calledContract).
-		        delegatecall(bytes4(keccak256("calledFunction()"))));
+        // Low-level calls using the address object for calledContract
+        require(
+            address(_calledContract).call(bytes4(keccak256("calledFunction()")))
+        );
 
-
-
-	}
+        require(
+            address(_calledContract).delegatecall(bytes4(keccak256("calledFunction()")))
+        );
+    }
 }

--- a/code/truffle/CallExamples/contracts/Migrations.sol
+++ b/code/truffle/CallExamples/contracts/Migrations.sol
@@ -1,23 +1,23 @@
 pragma solidity ^0.4.17;
 
 contract Migrations {
-  address public owner;
-  uint public last_completed_migration;
+    address public owner;
+    uint public last_completed_migration;
 
-  modifier restricted() {
-    if (msg.sender == owner) _;
-  }
+    modifier restricted() {
+        if (msg.sender == owner) _;
+    }
 
-  function Migrations() public {
-    owner = msg.sender;
-  }
+    function Migrations() public {
+        owner = msg.sender;
+    }
 
-  function setCompleted(uint completed) public restricted {
-    last_completed_migration = completed;
-  }
+    function setCompleted(uint completed) public restricted {
+        last_completed_migration = completed;
+    }
 
-  function upgrade(address new_address) public restricted {
-    Migrations upgraded = Migrations(new_address);
-    upgraded.setCompleted(last_completed_migration);
-  }
+    function upgrade(address new_address) public restricted {
+        Migrations upgraded = Migrations(new_address);
+        upgraded.setCompleted(last_completed_migration);
+    }
 }


### PR DESCRIPTION
1. contract elements layout order should be: Libraries -> Contracts
2. Inside each contract, library or interface, order should be: Events -> Functions
3. Contracts and libraries should be named using the CapWords style
4. Events should be named using the CapWords style
5. Surrounding top level declarations in solidity source with two blank lines.
6. Use 4 spaces per indentation level.