### PR TITLE
style: lint truffle's Faucet contracts

### DIFF
--- a/code/truffle/Faucet/contracts/Faucet.sol
+++ b/code/truffle/Faucet/contracts/Faucet.sol
@@ -3,18 +3,15 @@ pragma solidity ^0.4.19;
 
 // Our first contract is a faucet!
 contract Faucet {
+    // Accept any incoming amount
+    function () external payable {}
 
-	// Give out ether to anyone who asks
-	function withdraw(uint withdraw_amount) public {
+    // Give out ether to anyone who asks
+    function withdraw(uint withdraw_amount) public {
+        // Limit withdrawal amount
+        require(withdraw_amount <= 100000000000000000);
 
-    	// Limit withdrawal amount
-    	require(withdraw_amount <= 100000000000000000);
-
-    	// Send the amount to the address that requested it
-    	msg.sender.transfer(withdraw_amount);
+        // Send the amount to the address that requested it
+        msg.sender.transfer(withdraw_amount);
     }
-
-	// Accept any incoming amount
-	function () external payable {}
-
 }

--- a/code/truffle/Faucet/contracts/Migrations.sol
+++ b/code/truffle/Faucet/contracts/Migrations.sol
@@ -1,23 +1,23 @@
 pragma solidity ^0.4.17;
 
 contract Migrations {
-  address public owner;
-  uint public last_completed_migration;
+    address public owner;
+    uint public last_completed_migration;
 
-  modifier restricted() {
-    if (msg.sender == owner) _;
-  }
+    modifier restricted() {
+        if (msg.sender == owner) _;
+    }
 
-  function Migrations() public {
-    owner = msg.sender;
-  }
+    function Migrations() public {
+        owner = msg.sender;
+    }
 
-  function setCompleted(uint completed) public restricted {
-    last_completed_migration = completed;
-  }
+    function setCompleted(uint completed) public restricted {
+        last_completed_migration = completed;
+    }
 
-  function upgrade(address new_address) public restricted {
-    Migrations upgraded = Migrations(new_address);
-    upgraded.setCompleted(last_completed_migration);
-  }
+    function upgrade(address new_address) public restricted {
+        Migrations upgraded = Migrations(new_address);
+        upgraded.setCompleted(last_completed_migration);
+    }
 }


### PR DESCRIPTION
1. Functions should be grouped according to their visibility and ordered: external -> public
2. Use 4 spaces per indentation level.