### PR TITLE
style: lint truffle's FaucetEvents contracts

### DIFF
--- a/code/truffle/FaucetEvents/contracts/Faucet.sol
+++ b/code/truffle/FaucetEvents/contracts/Faucet.sol
@@ -1,42 +1,49 @@
 // Version of Solidity compiler this program was written for
 pragma solidity ^0.4.22;
 
-contract owned {
-	address owner;
-	// Contract constructor: set owner
-	constructor() {
-		owner = msg.sender;
-	}
-	// Access control modifier
-	modifier onlyOwner {
-	    require(msg.sender == owner, "Only the contract owner can call this function");
-	    _;
-	}
+contract Owned {
+    address owner;
+
+    // Contract constructor: set owner
+    constructor() {
+        owner = msg.sender;
+    }
+
+    // Access control modifier
+    modifier onlyOwner {
+        require(msg.sender == owner, "Only the contract owner can call this function");
+        _;
+    }
 }
 
-contract mortal is owned {
-	// Contract destructor
-	function destroy() public onlyOwner {
-		selfdestruct(owner);
-	}
+
+contract Mortal is Owned {
+    // Contract destructor
+    function destroy() public onlyOwner {
+        selfdestruct(owner);
+    }
 }
 
-contract Faucet is mortal {
-	event Withdrawal(address indexed to, uint amount);
-	event Deposit(address indexed from, uint amount);
+
+contract Faucet is Mortal {
+    event Withdrawal(address indexed to, uint amount);
+    event Deposit(address indexed from, uint amount);
+
+    // Accept any incoming amount
+    function () external payable {
+        emit Deposit(msg.sender, msg.value);
+    }
 
     // Give out ether to anyone who asks
     function withdraw(uint withdraw_amount) public {
         // Limit withdrawal amount
-		require(withdraw_amount <= 0.1 ether);
-		require(this.balance >= withdraw_amount,
-			"Insufficient balance in faucet for withdrawal request");
+        require(withdraw_amount <= 0.1 ether);
+        require(
+            this.balance >= withdraw_amount,
+            "Insufficient balance in faucet for withdrawal request"
+        );
         // Send the amount to the address that requested it
         msg.sender.transfer(withdraw_amount);
-		emit Withdrawal(msg.sender, withdraw_amount);
+        emit Withdrawal(msg.sender, withdraw_amount);
     }
-    // Accept any incoming amount
-    function () external payable {
-		emit Deposit(msg.sender, msg.value);
-	}
 }

--- a/code/truffle/FaucetEvents/contracts/Migrations.sol
+++ b/code/truffle/FaucetEvents/contracts/Migrations.sol
@@ -1,23 +1,23 @@
 pragma solidity ^0.4.17;
 
 contract Migrations {
-  address public owner;
-  uint public last_completed_migration;
+    address public owner;
+    uint public last_completed_migration;
 
-  modifier restricted() {
-    if (msg.sender == owner) _;
-  }
+    modifier restricted() {
+        if (msg.sender == owner) _;
+    }
 
-  function Migrations() public {
-    owner = msg.sender;
-  }
+    function Migrations() public {
+        owner = msg.sender;
+    }
 
-  function setCompleted(uint completed) public restricted {
-    last_completed_migration = completed;
-  }
+    function setCompleted(uint completed) public restricted {
+        last_completed_migration = completed;
+    }
 
-  function upgrade(address new_address) public restricted {
-    Migrations upgraded = Migrations(new_address);
-    upgraded.setCompleted(last_completed_migration);
-  }
+    function upgrade(address new_address) public restricted {
+        Migrations upgraded = Migrations(new_address);
+        upgraded.setCompleted(last_completed_migration);
+    }
 }


### PR DESCRIPTION
1. Surrounding top level declarations in solidity source with two blank lines.
2. Use 4 spaces per indentation level.
3. function order should be: constructor -> external -> public -> internal -> private