### PR TITLE
style: lint truffle's METoken contracts

### DIFF
--- a/code/truffle/METoken/contracts/METoken.sol
+++ b/code/truffle/METoken/contracts/METoken.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.21;
 
 import 'openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol';
 
+
 contract METoken is StandardToken {
     string public constant name = 'Mastering Ethereum Token';
     string public constant symbol = 'MET';

--- a/code/truffle/METoken/contracts/Migrations.sol
+++ b/code/truffle/METoken/contracts/Migrations.sol
@@ -1,23 +1,23 @@
 pragma solidity ^0.4.17;
 
 contract Migrations {
-  address public owner;
-  uint public last_completed_migration;
+    address public owner;
+    uint public last_completed_migration;
 
-  modifier restricted() {
-    if (msg.sender == owner) _;
-  }
+    modifier restricted() {
+        if (msg.sender == owner) _;
+    }
 
-  function Migrations() public {
-    owner = msg.sender;
-  }
+    function Migrations() public {
+        owner = msg.sender;
+    }
 
-  function setCompleted(uint completed) public restricted {
-    last_completed_migration = completed;
-  }
+    function setCompleted(uint completed) public restricted {
+        last_completed_migration = completed;
+    }
 
-  function upgrade(address new_address) public restricted {
-    Migrations upgraded = Migrations(new_address);
-    upgraded.setCompleted(last_completed_migration);
-  }
+    function upgrade(address new_address) public restricted {
+        Migrations upgraded = Migrations(new_address);
+        upgraded.setCompleted(last_completed_migration);
+    }
 }


### PR DESCRIPTION
1. Surrounding top level declarations in solidity source with two blank lines.
2. Use 4 spaces per indentation level.
