### PR TITLE
style: lint truffle's METoken_METFaucet contracts

### DIFF
--- a/code/truffle/METoken_METFaucet/contracts/METFaucet.sol
+++ b/code/truffle/METoken_METFaucet/contracts/METFaucet.sol
@@ -6,29 +6,25 @@ import 'openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol';
 
 // A faucet for ERC20 token MET
 contract METFaucet {
+    StandardToken public METoken;
+    address public METOwner;
 
-	StandardToken public METoken;
-	address public METOwner;
+    // REJECT any incoming ether
+    function () external payable { revert(); }
 
-	// METFaucet constructor, provide the address of METoken contract and
-	// the owner address we will be approved to transferFrom
-	function METFaucet(address _METoken, address _METOwner) public {
-
-		// Initialize the METoken from the address provided
-		METoken = StandardToken(_METoken);
-		METOwner = _METOwner;
-	}
-
-	function withdraw(uint withdraw_amount) public {
-
-    	// Limit withdrawal amount to 10 MET
-    	require(withdraw_amount <= 1000);
-
-		// Use the transferFrom function of METoken
-		METoken.transferFrom(METOwner, msg.sender, withdraw_amount);
+    // METFaucet constructor, provide the address of METoken contract and
+    // the owner address we will be approved to transferFrom
+    function METFaucet(address _METoken, address _METOwner) public {
+        // Initialize the METoken from the address provided
+        METoken = StandardToken(_METoken);
+        METOwner = _METOwner;
     }
 
-	// REJECT any incoming ether
-	function () external payable { revert(); }
+    function withdraw(uint withdraw_amount) public {
+        // Limit withdrawal amount to 10 MET
+        require(withdraw_amount <= 1000);
 
+        // Use the transferFrom function of METoken
+        METoken.transferFrom(METOwner, msg.sender, withdraw_amount);
+    }
 }

--- a/code/truffle/METoken_METFaucet/contracts/METoken.sol
+++ b/code/truffle/METoken_METFaucet/contracts/METoken.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.18;
 
 import 'openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol';
 
+
 contract METoken is StandardToken {
     string public constant name = 'Mastering Ethereum Token';
     string public constant symbol = 'MET';

--- a/code/truffle/METoken_METFaucet/contracts/Migrations.sol
+++ b/code/truffle/METoken_METFaucet/contracts/Migrations.sol
@@ -1,23 +1,23 @@
 pragma solidity ^0.4.17;
 
 contract Migrations {
-  address public owner;
-  uint public last_completed_migration;
+    address public owner;
+    uint public last_completed_migration;
 
-  modifier restricted() {
-    if (msg.sender == owner) _;
-  }
+    modifier restricted() {
+        if (msg.sender == owner) _;
+    }
 
-  function Migrations() public {
-    owner = msg.sender;
-  }
+    function Migrations() public {
+        owner = msg.sender;
+    }
 
-  function setCompleted(uint completed) public restricted {
-    last_completed_migration = completed;
-  }
+    function setCompleted(uint completed) public restricted {
+        last_completed_migration = completed;
+    }
 
-  function upgrade(address new_address) public restricted {
-    Migrations upgraded = Migrations(new_address);
-    upgraded.setCompleted(last_completed_migration);
-  }
+    function upgrade(address new_address) public restricted {
+        Migrations upgraded = Migrations(new_address);
+        upgraded.setCompleted(last_completed_migration);
+    }
 }


### PR DESCRIPTION
1. Surrounding top level declarations in solidity source with two blank lines.
2. Use 4 spaces per indentation level.
3. function order should be: constructor -> external -> public -> internal -> private