### PR TITLE
Exercise updates

### DIFF
--- a/06transactions.asciidoc
+++ b/06transactions.asciidoc
@@ -105,6 +105,10 @@ Let's look at an example:
 41
 </pre>
 ++++
+[TIP]
+====
+If you're trying to recreate these code examples yourself in Geth's javascript console, you should use web3.toWei() instead of web3.utils.toWei(). This is because Geth uses an older version of the web3 library.
+====
 
 As you can see, the first transaction we sent increased the transaction count to 41, showing the pending transaction. But when we sent three more transactions in quick succession, the +getTransactionCount+ call didn't count them. It only counted one, even though you might expect there to be three pending in the mempool. If we wait a few seconds to allow for network communications to settle down, the +getTransactionCount+ call will return the expected number. But in the interim, while there is more than one transaction pending, it might not help us.
 

--- a/06transactions.asciidoc
+++ b/06transactions.asciidoc
@@ -57,7 +57,7 @@ In summary, it is important to note that the use of the nonce is actually vital 
 [[tracking_nonce]]
 ==== Keeping Track of Nonces
 
-((("nonces","keeping track of")))In practical terms, the nonce is an up-to-date count of the number of _confirmed_ (i.e., on-chain) transactions that have originated from an account. To find out what the nonce is, you can interrogate the blockchain, for example via the web3 interface. Open a JavaScript console in a browser with MetaMask running, or use the +truffle console+ command to access the JavaScript web3 library, then type:
+((("nonces","keeping track of")))In practical terms, the nonce is an up-to-date count of the number of _confirmed_ (i.e., on-chain) transactions that have originated from an account. To find out what the nonce is, you can interrogate the blockchain, for example via the web3 interface. Open a JavaScript console in Geth (or your preferred web3 interface) on Ropsten testnet, then type:
 
 ++++
 <pre data-type="programlisting">


### PR DESCRIPTION
Meta mask is being deprecated so I added some advice about using geth console to do the javascript web3 exercises.

 In addition, i noted that the exercises should be done on Ropsten (this was not explained in the original text)