### PR TITLE
fix "Principles of Consensus"

### DIFF
--- a/14consensus.asciidoc
+++ b/14consensus.asciidoc
@@ -65,8 +65,7 @@ More information about Casper's history, ongoing research and future plans can b
 
 ((("consensus","principles of")))The principles and assumptions of consensus algorithms can be more clearly understood by asking a few key questions:
 
-* Who can change the past, and how? (This is also known as _immutability_.)
-* Who can change the future, and how? (This is also known as _finality_.)
+* Who can change the past, and how? (This is also known as _immutability_ or _finality_.)
 * What is the cost to make such changes?
 * How decentralized is the power to make such changes?
 * Who will know if something has changed, and how will they know?


### PR DESCRIPTION
I am not sure what it means by "change the future" in the original text.

From my perspective, future is not yet coming and remains unknow. How can someone manae to change it?

And moreover, "finality" is about whether a history block can be revoked. It looks more like "change the past" to me.