### PR TITLE
Update Faucet.sol to solidity v0.6

### DIFF
--- a/code/Solidity/Faucet.sol
+++ b/code/Solidity/Faucet.sol
@@ -1,9 +1,12 @@
 // Version of Solidity compiler this program was written for
-pragma solidity 0.5.12;
+pragma solidity ^0.6;
 
 // Our first contract is a faucet!
 contract Faucet {
 
+    // Accept any incoming amount
+    receive () external payable {}
+    
     // Give out ether to anyone who asks
     function withdraw(uint withdraw_amount) public {
 
@@ -13,8 +16,5 @@ contract Faucet {
         // Send the amount to the address that requested it
         msg.sender.transfer(withdraw_amount);
     }
-
-    // Accept any incoming amount
-    function () external payable {}
 
 }


### PR DESCRIPTION
-pragma ^0.6 for solc forward compatibility
-fallback function should now be receive() 
-function order should be: constructor -> external -> public -> internal -> private

Changes based on @HAOYUatHZ Pull request #931