### PR TITLE
fix: npm install sha3 1.2.0 fails - node10/npm6

### DIFF
--- a/code/auction_dapp/frontend/package-lock.json
+++ b/code/auction_dapp/frontend/package-lock.json
@@ -5414,7 +5414,7 @@
       "integrity": "sha1-HWM6+QfvMFu/ny+mFtVsRFYd+k0=",
       "requires": {
         "browserify-sha3": "0.0.1",
-        "sha3": "1.2.0"
+        "sha3": "1.2.1"
       }
     },
     "keyv": {


### PR DESCRIPTION
Fix npm sha3 issue by using sha3 1.2.1;

reference:
https://github.com/phusion/node-sha3/issues/32