### PR TITLE
Ganache Misc References

### DIFF
--- a/contrib/angular4-truffle.asciidoc
+++ b/contrib/angular4-truffle.asciidoc
@@ -168,7 +168,7 @@ module.exports = {
   // to customize your Truffle configuration!
   networks: {
     development: {
-      host: "0.0.0.0",//If your using Truffle testnet or ganache then replace it with local ip or localhost.
+      host: "0.0.0.0",//If you're using Truffle testnet or ganache then replace it with local ip or localhost.
       port: 8545, // Port number on which the private or testnet is hosted on.
       gas: 550000, //Provide necessary gas
       network_id: "*" // Match any network id


### PR DESCRIPTION
Adrian from the Truffle team here to correct references to Ganache. Files reviewed:

```
contrib/angular4-truffle.asciidoc
contrib/ethereum-testnets.asciidoc
misc/example_keys.txt
```

Please see the following issue for more details: https://github.com/ethereumbook/ethereumbook/issues/955#issuecomment-599199460