### PR TITLE
Ganache Text References

### DIFF
--- a/03clients.asciidoc
+++ b/03clients.asciidoc
@@ -88,16 +88,17 @@ You also have the option of running a remote client, which does not store a loca
 *Advantages:*
 
 * No syncing and almost no data on disk; you mine the first block yourself
-* No need to obtain test ether; you "award" yourself mining rewards that you can use for testing
+* No need to obtain test ether; Ganache is initialized with accounts that already hold ether for testing
 * No other users, just you
-* No other contracts, just the ones you deploy after you launch it
+* No other contracts, just the ones you deploy after you launch it unless you use the option of forking off an existing Ethereum node
 
 *Disadvantages:*
 
 * Having no other users means that it doesn't behave the same as a public blockchain. There's no competition for transaction space or sequencing of pass:[<span class="keep-together">transactions</span>].
 * No miners other than you means that mining is more predictable; therefore, you can't test some scenarios that occur on a public blockchain.
-* Having no other contracts means you have to deploy everything that you want to test, including dependencies and contract libraries.
-* You can't recreate some of the public contracts and their addresses to test some scenarios (e.g., the DAO contract).(((range="endofrange", startref="ix_03clients-asciidoc2")))(((range="endofrange", startref="ix_03clients-asciidoc1")))
+* If you are forking off an existing Ethereum node, it will need to be an archival node for you to interact with state from blocks that may have been pruned otherwise
+
+(((range="endofrange", startref="ix_03clients-asciidoc2")))(((range="endofrange", startref="ix_03clients-asciidoc1")))
 
 
 [[running_client]]

--- a/appdx-dev-tools.asciidoc
+++ b/appdx-dev-tools.asciidoc
@@ -648,8 +648,8 @@ Documentation: https://docs.etcdevteam.com[]
 .Smart contract test frameworks summary
 |=======
 |Framework | Test language(s)    | Testing framework | Chain emulator       | Website
-|Truffle   | JavaScript/Solidity | Mocha             | TestRPC/Ganache      | https://truffleframework.com/[]
-|Embark    | JavaScript          | Mocha             | TestRPC/Ganache      | https://embark.status.im/docs/[]
+|Truffle   | JavaScript/Solidity | Mocha             | Ganache      | https://truffleframework.com/[]
+|Embark    | JavaScript          | Mocha             | Ganache      | https://embark.status.im/docs/[]
 |Dapp      | Solidity            | +ds-test+ (custom)  | +ethrun+ (Parity)      | https://dapp.tools/dapp/[]
 |Populus   | Python              | +pytest+             | Python chain emulator| https://populus.readthedocs.io[]
 |=======
@@ -657,7 +657,7 @@ Documentation: https://docs.etcdevteam.com[]
 
 Truffle:: ((("Truffle","as test framework")))Truffle allows for unit tests to be written in JavaScript (Mocha-based) or Solidity. These tests are run against Ganache.
 
-Embark:: ((("Embark")))Embark integrates with Mocha to run unit tests written in JavaScript. The tests are in turn run against contracts deployed on TestRPC/Ganache. The Embark framework automatically deploys smart contracts, and will automatically redeploy the contracts when they are changed. It also keeps track of deployed contracts and deploys contracts only when truly needed. Embark includes a testing library to rapidly run and test your contracts in an EVM, with functions like +assert.equal+. The command +embark test+ will run any test files under the directory _test_.
+Embark:: ((("Embark")))Embark integrates with Mocha to run unit tests written in JavaScript. The tests are in turn run against contracts deployed on Ganache (formerly called TestRPC). The Embark framework automatically deploys smart contracts, and will automatically redeploy the contracts when they are changed. It also keeps track of deployed contracts and deploys contracts only when truly needed. Embark includes a testing library to rapidly run and test your contracts in an EVM, with functions like +assert.equal+. The command +embark test+ will run any test files under the directory _test_.
 
 Dapp:: ((("Dapp")))Dapp uses native Solidity code (a library called +ds-test+) and a Parity-built Rust library called +ethrun+ to execute Ethereum bytecode and then assert correctness. The +ds-test+ library provides assertion functions for validating correctness and events for logging data in the console.
 +

--- a/appdx-dev-tools.asciidoc
+++ b/appdx-dev-tools.asciidoc
@@ -757,6 +757,6 @@ $ <strong>ganache-cli \
 
 A few notes on this command line:
 
-* [ ] Check the `--networkId` and `--port` flag values match your configuration in _truffle.js_.
+* [ ] Check the `--networkId` and `--port` flag values match your configuration in _truffle-config.js_.
 * [ ] Check the `--gasLimit` flag value matches the latest mainnet gas limit (e.g., 8,000,000 gas) shown at https://ethstats.net to avoid encountering &#x201c;out of gas&#x201d; exceptions unnecessarily. Note that a `--gasPrice` of +4000000000+ represents a gas price of 4 gwei.
 * [ ] You can optionally enter a `--mnemonic` flag value to restore a previous HD wallet and associated addresses.(((range="endofrange", startref="ix_appdx-dev-tools-asciidoc13")))(((range="endofrange", startref="ix_appdx-dev-tools-asciidoc12")))(((range="endofrange", startref="ix_appdx-dev-tools-asciidoc11")))


### PR DESCRIPTION
Adrian from the Truffle team here to correct references to Ganache. Files reviewed:

```
03clients.asciidoc
10tokens.asciidoc
appdx-dev-tools.asciidoc
glossary.asciidoc
```

Please see the following issue for more details: https://github.com/ethereumbook/ethereumbook/issues/955#issuecomment-599199460