### PR TITLE
Fix typo from ERC59 to EIP-59

### DIFF
--- a/04keys-addresses.asciidoc
+++ b/04keys-addresses.asciidoc
@@ -415,7 +415,7 @@ Regardless of what the function is called, you can test it to see whether it is 
 
 [NOTE]
 ====
-Due to the confusion created by the difference between the hash function used in Ethereum (Keccak-256) and the finalized standard (FIP-202 SHA-3), there is an effort underway to rename all instances of +sha3+ in all code, opcodes, and libraries to +keccak256+. See https://github.com/ethereum/EIPs/issues/59[ERC59] for details.
+Due to the confusion created by the difference between the hash function used in Ethereum (Keccak-256) and the finalized standard (FIP-202 SHA-3), there is an effort underway to rename all instances of +sha3+ in all code, opcodes, and libraries to +keccak256+. See https://github.com/ethereum/EIPs/issues/59[EIP-59] for details.
 ====
 
 


### PR DESCRIPTION
The text references EIP-59 but then calls it "ERC59" in the link's title. I think it should be "EIP-59" instead.