### PR TITLE
Chapter 7: Fix reference to Event name

### DIFF
--- a/07smart-contracts-solidity.asciidoc
+++ b/07smart-contracts-solidity.asciidoc
@@ -877,7 +877,7 @@ include::code/truffle/CallExamples/contracts/CallExamples.sol[]
 ----
 ====
 
-As you can see in this example, our main contract is +caller+, which calls a library +calledLibrary+ and a contract +calledContract+. Both the called library and the contract have identical +calledFunction+ functions, which emit an event +calledEvent+. The event +calledEvent+ logs three pieces of data: +msg.sender+, +tx.origin+, and +this+. Each time +calledFunction+ is called it may have a different execution context (with different values for potentially all the context variables), depending on whether it is called directly or through +delegatecall+.
+As you can see in this example, our main contract is +caller+, which calls a library +calledLibrary+ and a contract +calledContract+. Both the called library and the contract have identical +calledFunction+ functions, which emit an event +callEvent+. The event +callEvent+ logs three pieces of data: +msg.sender+, +tx.origin+, and +this+. Each time +calledFunction+ is called it may have a different execution context (with different values for potentially all the context variables), depending on whether it is called directly or through +delegatecall+.
 
 In +caller+, we first call the contract and library directly, by invoking +calledFunction+ in each. Then, we explicitly use the low-level functions +call+ and +delegatecall+ to call +calledContract.calledFunction+. This way we can see how the various calling mechanisms behave.
 


### PR DESCRIPTION
The correct event name, as seen in https://github.com/ethereumbook/ethereumbook/blob/develop/code/truffle/CallExamples/contracts/CallExamples.sol, is 'callEvent', not 'calledEvent'.