### PR TITLE
change account[n] to accounts[n] chapter10

### DIFF
--- a/10tokens.asciidoc
+++ b/10tokens.asciidoc
@@ -458,7 +458,7 @@ truffle(ganache)&gt; <strong>accounts[0]</strong>
 </pre>
 ++++
 
-The +accounts+ list now contains all the accounts created by +ganache+, and +account[0]+ is the account that deployed the +METoken+ contract. It should have a balance of pass:[<span class="keep-together">METoken</span>], because our METoken constructor gives the entire token supply to the address that created it. Let's check:
+The +accounts+ list now contains all the accounts created by +ganache+, and +accounts[0]+ is the account that deployed the +METoken+ contract. It should have a balance of pass:[<span class="keep-together">METoken</span>], because our METoken constructor gives the entire token supply to the address that created it. Let's check:
 
 ++++
 <pre data-type="programlist">
@@ -469,7 +469,7 @@ truffle(ganache)&gt; <strong>BigNumber { s: 1, e: 9, c: [ 2100000000 ] }</strong
 </pre>
 ++++
 
-Finally, let's transfer 1000.00 METoken from +account[0]+ to +account[1]+, by calling the contract's +transfer+ function:
+Finally, let's transfer 1000.00 METoken from +accounts[0]+ to +accounts[1]+, by calling the contract's +transfer+ function:
 
 ++++
 <pre data-type="programlist">
@@ -493,7 +493,7 @@ truffle(ganache)&gt; <strong>BigNumber { s: 1, e: 5, c: [ 100000 ] }</strong>
 METoken has 2 decimals of precision, meaning that 1 METoken is 100 units in the contract. When we transfer 1,000 METoken, we specify the value as +100000+ in the call to the +transfer+ function.
 ====
 
-As you can see, in the console, +account[0]+ now has 20,999,000 MET, and +account[1]+ has 1,000 MET.
+As you can see, in the console, +accounts[0]+ now has 20,999,000 MET, and +accounts[1]+ has 1,000 MET.
 
 If you switch to the +ganache+ graphical user interface, as shown in <<ganache_METoken_transfer>>, you will see the transaction that called the +transfer+ function.(((range="endofrange", startref="ix_10tokens-asciidoc12")))(((range="endofrange", startref="ix_10tokens-asciidoc11")))
 


### PR DESCRIPTION
web3 uses `accounts[n]` (instead of `account[n]`), to select an element of the `accounts` array. Little mistakes in paragraphs 461, 472 & 496 (as far as I find them).