### PR TITLE
Update 02intro.asciidoc: Conclusions links

### DIFF
--- a/02intro.asciidoc
+++ b/02intro.asciidoc
@@ -557,4 +557,4 @@ Next, you wrote a faucet contract in Solidity. You used the Remix IDE to compile
 
 It may not seem like much, but you've just successfully interacted with software that controls money on a decentralized world computer.
 
-We will do a lot more smart contract programming in <<smart_contracts_chapter>> and learn about best practices and security considerations in <<smart_contract_security>>.(((range="endofrange", startref="ix_02intro-asciidoc0")))
+We will do a lot more smart contract programming in link:07smart-contracts-solidity.asciidoc[[smart_contracts_chapter]] and learn about best practices and security considerations in link:09smart-contracts-security.asciidoc[[smart_contract_security]].


### PR DESCRIPTION
Fix `Conclusions` chapters links (with  the convention that's followed the book for cross-linking).