### PR TITLE
Chapter 10: Fix deployment script of METoken and METFaucet

### DIFF
--- a/10tokens.asciidoc
+++ b/10tokens.asciidoc
@@ -652,10 +652,10 @@ Now that our _METFaucet.sol_ code is ready, we need to modify the migration scri
 ----
 var METoken = artifacts.require("METoken");
 var METFaucet = artifacts.require("METFaucet");
-var owner = web3.eth.accounts[0];
 
-module.exports = function(deployer) {
+module.exports = function(deployer, network, accounts) {
 
+	var owner = accounts[0];
 	// Deploy the METoken contract first
 	deployer.deploy(METoken, {from: owner}).then(function() {
 		// Then deploy METFaucet and pass the address of METoken and the

--- a/github_contrib.asciidoc
+++ b/github_contrib.asciidoc
@@ -147,6 +147,7 @@ Following is an alphabetically sorted list of all the GitHub contributors, inclu
 * Tomoya Ishizaki (zaq1tomo)
 * Ulrich Stark (ulrichstark)
 * Vignesh Karthikeyan (meshugah)
+* Vuksan Simunović (Vuksan)
 * westerpants (westerpants)
 * Will Binns (wbnns)
 * Xavier Lavayssière (xalava)


### PR DESCRIPTION
Current `2_deploy_contracts.js` fails when run.
`web3.eth.accounts` have been deprecated, and `accounts[0]` returns `undefined`.

Truffle migrations are passed the list of accounts as stated [here](https://www.trufflesuite.com/docs/truffle/getting-started/running-migrations#available-accounts).

_Note:_ Following the guide on [Contributing](https://github.com/ethereumbook/ethereumbook/blob/develop/CONTRIBUTING.md) I have added my name (and GitHub account) under contributors. Feel free to move it to a more appropriate location, or remove it completely if the proposed change is too small/obvious for it.