### PR TITLE
Added chapter numbers and links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Mastering Ethereum is a book for developers, offering a guide to the operation a
 To read this book, see [book.asciidoc](https://github.com/ethereumbook/ethereumbook/blob/develop/book.asciidoc). Click on each of the chapters to read in your browser. Other parties may choose to release PDFs of the book online.
 
 ## Chapters
-
++ Preface: '[Preface](https://github.com/ethereumbook/ethereumbook/blob/develop/preface.asciidoc)'
 + Chapter 1: '[What Is Ethereum](https://github.com/ethereumbook/ethereumbook/blob/develop/01what-is.asciidoc)'
 + Chapter 2: '[Ehtereum Basics](https://github.com/ethereumbook/ethereumbook/blob/develop/02intro.asciidoc)'
 + Chapter 3: '[Ethereum Clients](https://github.com/ethereumbook/ethereumbook/blob/develop/03clients.asciidoc)'

--- a/README.md
+++ b/README.md
@@ -8,6 +8,23 @@ Mastering Ethereum is a book for developers, offering a guide to the operation a
 
 To read this book, see [book.asciidoc](https://github.com/ethereumbook/ethereumbook/blob/develop/book.asciidoc). Click on each of the chapters to read in your browser. Other parties may choose to release PDFs of the book online.
 
+## Chapters
+
++ Chapter 1: '[What Is Ethereum](https://github.com/ethereumbook/ethereumbook/blob/develop/01what-is.asciidoc)'
++ Chapter 2: '[Ehtereum Basics](https://github.com/ethereumbook/ethereumbook/blob/develop/02intro.asciidoc)'
++ Chapter 3: '[Ethereum Clients](https://github.com/ethereumbook/ethereumbook/blob/develop/03clients.asciidoc)'
++ Chapter 4: '[Cryptography](https://github.com/ethereumbook/ethereumbook/blob/develop/04keys-addresses.asciidoc)'
++ Chapter 5: '[Wallets](https://github.com/ethereumbook/ethereumbook/blob/develop/05wallets.asciidoc)'
++ Chapter 6: '[Transactions](https://github.com/ethereumbook/ethereumbook/blob/develop/06transactions.asciidoc)'
++ Chapter 7: '[Smart Contracts and Solidity](https://github.com/ethereumbook/ethereumbook/blob/develop/07smart-contracts-solidity.asciidoc)'
++ Chapter 8: '[Smart Contracts and Vyper](https://github.com/ethereumbook/ethereumbook/blob/develop/08smart-contracts-vyper.asciidoc)'
++ Chapter 9: '[Smart Contract Security](https://github.com/ethereumbook/ethereumbook/blob/develop/09smart-contracts-security.asciidoc)'
++ Chapter 10: '[Tokens](https://github.com/ethereumbook/ethereumbook/blob/develop/10tokens.asciidoc)'
++ Chapter 11: '[Oracles](https://github.com/ethereumbook/ethereumbook/blob/develop/11oracles.asciidoc)'
++ Chapter 12: '[Decentralized Applications (DApps)](https://github.com/ethereumbook/ethereumbook/blob/develop/12dapps.asciidoc)'
++ Chapter 13: '[The Ethereum Virtual Machine](https://github.com/ethereumbook/ethereumbook/blob/develop/13evm.asciidoc)'
++ Chapter 14: '[Consensus](https://github.com/ethereumbook/ethereumbook/blob/develop/14consensus.asciidoc)'
+
 ## Content
 
 The content status is "COMPLETE". The first edition of this book was published on December 1st, 2018. That edition is available in print and ebook format at many popular bookstores. It is tagged ["first_edition_first_print"](https://github.com/ethereumbook/ethereumbook/tree/first_edition_first_print) in the develop branch of this repository.


### PR DESCRIPTION

This is only a cosmetic change intended to increase the usability of the book

While reading the digital version of the [Bitcoin Book](https://github.com/bitcoinbook/bitcoinbook/) I found the table of contents like section titled ["Chapters"](https://github.com/bitcoinbook/bitcoinbook#chapters) to be very helpful. I have added the same section for this book here, following the same format as well as including the Preface which I find to be an important addition.