### PR TITLE
Fix undeclared identifiers

### DIFF
--- a/09smart-contracts-security.asciidoc
+++ b/09smart-contracts-security.asciidoc
@@ -319,8 +319,9 @@ contract TimeLock {
     function withdraw() public {
         require(balances[msg.sender] > 0);
         require(now > lockTime[msg.sender]);
+        uint transferValue = balances[msg.sender];
         balances[msg.sender] = 0;
-        msg.sender.transfer(balance);
+        msg.sender.transfer(transferValue);
     }
 }
 ----
@@ -457,8 +458,9 @@ contract TimeLock {
     function withdraw() public {
         require(balances[msg.sender] > 0);
         require(now > lockTime[msg.sender]);
+        uint256 transferValue = balances[msg.sender];
         balances[msg.sender] = 0;
-        msg.sender.transfer(balance);
+        msg.sender.transfer(transferValue);
     }
 }
 ----
@@ -587,6 +589,7 @@ contract EtherGame {
         require(this.balance == finalMileStone);
         // ensure there is a reward to give
         require(redeemableEther[msg.sender] > 0);
+        uint transferValue = redeemableEther[msg.sender];
         redeemableEther[msg.sender] = 0;
         msg.sender.transfer(transferValue);
     }
@@ -669,6 +672,7 @@ contract EtherGame {
         require(depositedWei == finalMileStone);
         // ensure there is a reward to give
         require(redeemableEther[msg.sender] > 0);
+        uint transferValue = redeemableEther[msg.sender];
         redeemableEther[msg.sender] = 0;
         msg.sender.transfer(transferValue);
     }

--- a/10tokens.asciidoc
+++ b/10tokens.asciidoc
@@ -906,7 +906,7 @@ interface ERC721 /* is ERC165 */ {
     function transferFrom(address _from, address _to, uint256 _deedId)
         external payable;
     function approve(address _approved, uint256 _deedId) external payable;
-    function setApprovalForAll(address _operateor, boolean _approved) payable;
+    function setApprovalForAll(address _operator, boolean _approved) payable;
     function supportsInterface(bytes4 interfaceID) external view returns (bool);
 }
 ----


### PR DESCRIPTION
The `balance` and `transferValue` variables in the `TimeLock` and `EtherGame` contracts are undeclared. Also, I renamed the `balance` variables to `transferValue` in the `TimeLock` contract to avoid confusion with the `this.balance` variable and for consistency.