### PR TITLE
Update keyword and syntax of Auction DApp to work with Solidity 0.5.16.

### DIFF
--- a/code/auction_dapp/backend/contracts/AuctionRepository.sol
+++ b/code/auction_dapp/backend/contracts/AuctionRepository.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.17;
+pragma solidity ^0.5.16;
 
 import "./DeedRepository.sol";
 
@@ -20,7 +20,7 @@ contract AuctionRepository {
 
     // Bid struct to hold bidder and amount
     struct Bid {
-        address from;
+        address payable from;
         uint256 amount;
     }
 
@@ -32,7 +32,7 @@ contract AuctionRepository {
         string metadata;
         uint256 deedId;
         address deedRepositoryAddress;
-        address owner;
+        address payable owner;
         bool active;
         bool finalized;
     }
@@ -60,7 +60,7 @@ contract AuctionRepository {
     /**
     * @dev Disallow payments to this contract directly
     */
-    function() public{
+    function() external {
         revert();
     }
 
@@ -68,7 +68,7 @@ contract AuctionRepository {
     * @dev Gets the length of auctions
     * @return uint representing the auction count
     */
-    function getCount() public constant returns(uint) {
+    function getCount() public view returns(uint) {
         return auctions.length;
     }
 
@@ -76,7 +76,7 @@ contract AuctionRepository {
     * @dev Gets the bid counts of a given auction
     * @param _auctionId uint ID of the auction
     */
-    function getBidsCount(uint _auctionId) public constant returns(uint) {
+    function getBidsCount(uint _auctionId) public view returns(uint) {
         return auctionBids[_auctionId].length;
     }
 
@@ -84,7 +84,7 @@ contract AuctionRepository {
     * @dev Gets an array of owned auctions
     * @param _owner address of the auction owner
     */
-    function getAuctionsOf(address _owner) public constant returns(uint[]) {
+    function getAuctionsOf(address _owner) public view returns(uint[] memory) {
         uint[] memory ownedAuctions = auctionOwner[_owner];
         return ownedAuctions;
     }
@@ -94,14 +94,14 @@ contract AuctionRepository {
     * @param _auctionId uint of the auction owner
     * @return amount uint256, address of last bidder
     */
-    function getCurrentBid(uint _auctionId) public constant returns(uint256, address) {
+    function getCurrentBid(uint _auctionId) public view returns(uint256, address) {
         uint bidsLength = auctionBids[_auctionId].length;
         // if there are bids refund the last bid
         if( bidsLength > 0 ) {
             Bid memory lastBid = auctionBids[_auctionId][bidsLength - 1];
             return (lastBid.amount, lastBid.from);
         }
-        return (0, 0);
+        return (uint256(0), address(0));
     }
 
     /**
@@ -109,7 +109,7 @@ contract AuctionRepository {
     * @param _owner address of the owner
     * @return uint total number of auctions
     */
-    function getAuctionsCountOfOwner(address _owner) public constant returns(uint) {
+    function getAuctionsCountOfOwner(address _owner) public view returns(uint) {
         return auctionOwner[_owner].length;
     }
 
@@ -126,11 +126,11 @@ contract AuctionRepository {
     * @return bool whether the auction is active
     * @return bool whether the auction is finalized
     */
-    function getAuctionById(uint _auctionId) public constant returns(
-        string name,
+    function getAuctionById(uint _auctionId) public view returns(
+        string memory name,
         uint256 blockDeadline,
         uint256 startPrice,
-        string metadata,
+        string memory metadata,
         uint256 deedId,
         address deedRepositoryAddress,
         address owner,
@@ -160,7 +160,7 @@ contract AuctionRepository {
     * @param _blockDeadline uint is the timestamp in which the auction expires
     * @return bool whether the auction is created
     */
-    function createAuction(address _deedRepositoryAddress, uint256 _deedId, string _auctionTitle, string _metadata, uint256 _startPrice, uint _blockDeadline) public contractIsDeedOwner(_deedRepositoryAddress, _deedId) returns(bool) {
+    function createAuction(address _deedRepositoryAddress, uint256 _deedId, string memory _auctionTitle, string memory _metadata, uint256 _startPrice, uint _blockDeadline) public contractIsDeedOwner(_deedRepositoryAddress, _deedId) returns(bool) {
         uint auctionId = auctions.length;
         Auction memory newAuction;
         newAuction.name = _auctionTitle;

--- a/code/auction_dapp/backend/contracts/DeedRepository.sol
+++ b/code/auction_dapp/backend/contracts/DeedRepository.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.17;
+pragma solidity ^0.5.16;
 import "./ERC721/ERC721Token.sol";
 
 /**
@@ -15,7 +15,7 @@ contract DeedRepository is ERC721Token {
     * @param _name string represents the name of the repository
     * @param _symbol string represents the symbol of the repository
     */
-    function DeedRepository(string _name, string _symbol) 
+    constructor(string memory _name, string memory _symbol) 
         public ERC721Token(_name, _symbol) {}
     
     /**
@@ -24,7 +24,7 @@ contract DeedRepository is ERC721Token {
     * @param _tokenId uint256 represents a specific deed
     * @param _uri string containing metadata/uri
     */
-    function registerDeed(uint256 _tokenId, string _uri) public {
+    function registerDeed(uint256 _tokenId, string memory _uri) public {
         _mint(msg.sender, _tokenId);
         addDeedMetadata(_tokenId, _uri);
         emit DeedRegistered(msg.sender, _tokenId);
@@ -36,7 +36,7 @@ contract DeedRepository is ERC721Token {
     * @param _uri text which describes the characteristics of a given deed
     * @return whether the deed metadata was added to the repository
     */
-    function addDeedMetadata(uint256 _tokenId, string _uri) public returns(bool){
+    function addDeedMetadata(uint256 _tokenId, string memory _uri) public returns(bool){
         _setTokenURI(_tokenId, _uri);
         return true;
     }

--- a/code/auction_dapp/backend/contracts/ERC721/DeprecatedERC721.sol
+++ b/code/auction_dapp/backend/contracts/ERC721/DeprecatedERC721.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.5.16;
 
 import "./ERC721.sol";
 
@@ -11,5 +11,5 @@ import "./ERC721.sol";
 contract DeprecatedERC721 is ERC721 {
   function takeOwnership(uint256 _tokenId) public;
   function transfer(address _to, uint256 _tokenId) public;
-  function tokensOf(address _owner) public view returns (uint256[]);
+  function tokensOf(address _owner) public view returns (uint256[] memory);
 }

--- a/code/auction_dapp/backend/contracts/ERC721/ERC721.sol
+++ b/code/auction_dapp/backend/contracts/ERC721/ERC721.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.5.16;
 
 import "./ERC721Basic.sol";
 
@@ -19,9 +19,9 @@ contract ERC721Enumerable is ERC721Basic {
  * @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md
  */
 contract ERC721Metadata is ERC721Basic {
-  function name() public view returns (string _name);
-  function symbol() public view returns (string _symbol);
-  function tokenURI(uint256 _tokenId) public view returns (string);
+  function name() public view returns (string memory _name);
+  function symbol() public view returns (string memory _symbol);
+  function tokenURI(uint256 _tokenId) public view returns (string memory);
 }
 
 

--- a/code/auction_dapp/backend/contracts/ERC721/ERC721Basic.sol
+++ b/code/auction_dapp/backend/contracts/ERC721/ERC721Basic.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.5.16;
 
 
 /**
@@ -26,7 +26,7 @@ contract ERC721Basic {
     address _from,
     address _to,
     uint256 _tokenId,
-    bytes _data
+    bytes memory _data
   )
     public;
 }

--- a/code/auction_dapp/backend/contracts/ERC721/ERC721BasicToken.sol
+++ b/code/auction_dapp/backend/contracts/ERC721/ERC721BasicToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.5.16;
 
 import "./ERC721Basic.sol";
 import "./ERC721Receiver.sol";
@@ -94,7 +94,7 @@ contract ERC721BasicToken is ERC721Basic {
 
     if (getApproved(_tokenId) != address(0) || _to != address(0)) {
       tokenApprovals[_tokenId] = _to;
-      Approval(owner, _to, _tokenId);
+      emit Approval(owner, _to, _tokenId);
     }
   }
 
@@ -116,7 +116,7 @@ contract ERC721BasicToken is ERC721Basic {
   function setApprovalForAll(address _to, bool _approved) public {
     require(_to != msg.sender);
     operatorApprovals[msg.sender][_to] = _approved;
-    ApprovalForAll(msg.sender, _to, _approved);
+    emit ApprovalForAll(msg.sender, _to, _approved);
   }
 
   /**
@@ -145,7 +145,7 @@ contract ERC721BasicToken is ERC721Basic {
     removeTokenFrom(_from, _tokenId);
     addTokenTo(_to, _tokenId);
 
-    Transfer(_from, _to, _tokenId);
+    emit Transfer(_from, _to, _tokenId);
   }
 
   /**
@@ -186,7 +186,7 @@ contract ERC721BasicToken is ERC721Basic {
     address _from,
     address _to,
     uint256 _tokenId,
-    bytes _data
+    bytes memory _data
   )
     public
     canTransfer(_tokenId)
@@ -216,7 +216,7 @@ contract ERC721BasicToken is ERC721Basic {
   function _mint(address _to, uint256 _tokenId) internal {
     require(_to != address(0));
     addTokenTo(_to, _tokenId);
-    Transfer(address(0), _to, _tokenId);
+    emit Transfer(address(0), _to, _tokenId);
   }
 
   /**
@@ -227,7 +227,7 @@ contract ERC721BasicToken is ERC721Basic {
   function _burn(address _owner, uint256 _tokenId) internal {
     clearApproval(_owner, _tokenId);
     removeTokenFrom(_owner, _tokenId);
-    Transfer(_owner, address(0), _tokenId);
+    emit Transfer(_owner, address(0), _tokenId);
   }
 
   /**
@@ -240,7 +240,7 @@ contract ERC721BasicToken is ERC721Basic {
     require(ownerOf(_tokenId) == _owner);
     if (tokenApprovals[_tokenId] != address(0)) {
       tokenApprovals[_tokenId] = address(0);
-      Approval(_owner, address(0), _tokenId);
+      emit Approval(_owner, address(0), _tokenId);
     }
   }
 
@@ -279,7 +279,7 @@ contract ERC721BasicToken is ERC721Basic {
     address _from,
     address _to,
     uint256 _tokenId,
-    bytes _data
+    bytes memory _data
   )
     internal
     returns (bool)

--- a/code/auction_dapp/backend/contracts/ERC721/ERC721Holder.sol
+++ b/code/auction_dapp/backend/contracts/ERC721/ERC721Holder.sol
@@ -1,10 +1,10 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.5.16;
 
 import "./ERC721Receiver.sol";
 
 
 contract ERC721Holder is ERC721Receiver {
-  function onERC721Received(address, uint256, bytes) public returns(bytes4) {
+  function onERC721Received(address, uint256, bytes memory) public returns(bytes4) {
     return ERC721_RECEIVED;
   }
 }

--- a/code/auction_dapp/backend/contracts/ERC721/ERC721Receiver.sol
+++ b/code/auction_dapp/backend/contracts/ERC721/ERC721Receiver.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.5.16;
 
 
 /**
@@ -26,5 +26,5 @@ contract ERC721Receiver {
    * @param _data Additional data with no specified format
    * @return `bytes4(keccak256("onERC721Received(address,uint256,bytes)"))`
    */
-  function onERC721Received(address _from, uint256 _tokenId, bytes _data) public returns(bytes4);
+  function onERC721Received(address _from, uint256 _tokenId, bytes memory _data) public returns(bytes4);
 }

--- a/code/auction_dapp/backend/contracts/ERC721/ERC721Token.sol
+++ b/code/auction_dapp/backend/contracts/ERC721/ERC721Token.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.5.16;
 
 import "./ERC721.sol";
 import "./DeprecatedERC721.sol";
@@ -36,7 +36,7 @@ contract ERC721Token is ERC721, ERC721BasicToken {
   /**
   * @dev Constructor function
   */
-  function ERC721Token(string _name, string _symbol) public {
+  constructor(string memory _name, string memory _symbol) public {
     name_ = _name;
     symbol_ = _symbol;
   }
@@ -45,7 +45,7 @@ contract ERC721Token is ERC721, ERC721BasicToken {
   * @dev Gets the token name
   * @return string representing the token name
   */
-  function name() public view returns (string) {
+  function name() public view returns (string memory) {
     return name_;
   }
 
@@ -53,7 +53,7 @@ contract ERC721Token is ERC721, ERC721BasicToken {
   * @dev Gets the token symbol
   * @return string representing the token symbol
   */
-  function symbol() public view returns (string) {
+  function symbol() public view returns (string memory) {
     return symbol_;
   }
 
@@ -62,7 +62,7 @@ contract ERC721Token is ERC721, ERC721BasicToken {
   * @dev Throws if the token ID does not exist. May return an empty string.
   * @param _tokenId uint256 ID of the token to query
   */
-  function tokenURI(uint256 _tokenId) public view returns (string) {
+  function tokenURI(uint256 _tokenId) public view returns (string memory) {
     require(exists(_tokenId));
     return tokenURIs[_tokenId];
   }
@@ -103,7 +103,7 @@ contract ERC721Token is ERC721, ERC721BasicToken {
   * @param _tokenId uint256 ID of the token to set its URI
   * @param _uri string URI to assign
   */
-  function _setTokenURI(uint256 _tokenId, string _uri) internal {
+  function _setTokenURI(uint256 _tokenId, string memory _uri) internal {
     require(exists(_tokenId));
     tokenURIs[_tokenId] = _uri;
   }

--- a/code/auction_dapp/backend/contracts/Migrations.sol
+++ b/code/auction_dapp/backend/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.17;
+pragma solidity ^0.5.16;
 
 contract Migrations {
     address public owner;
@@ -8,7 +8,7 @@ contract Migrations {
         if (msg.sender == owner) _;
     }
 
-    function Migrations() public {
+    constructor() public {
         owner = msg.sender;
     }
 

--- a/code/auction_dapp/backend/contracts/utils/AddressUtils.sol
+++ b/code/auction_dapp/backend/contracts/utils/AddressUtils.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.5.16;
 
 
 /**

--- a/code/auction_dapp/backend/contracts/utils/math/Math.sol
+++ b/code/auction_dapp/backend/contracts/utils/math/Math.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.5.16;
 
 
 /**

--- a/code/auction_dapp/backend/contracts/utils/math/SafeMath.sol
+++ b/code/auction_dapp/backend/contracts/utils/math/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.5.16;
 
 
 /**


### PR DESCRIPTION
After installing `truffle`, I have found that we cannot easily downgrade to an older solidity. As such I cannot deploy the Auction DApp's contracts without updating the syntax of the code to a newer solidity. 

I went through and updated the pragmas to support 0.5.16, and I fixed all of the syntax issues the compiler was complaining about. After this, I was able to successfully deploy to a local geth node into Ropsten, so we should be good to go...

