### PR TITLE
Fix constant width example styling in preface

### DIFF
--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -35,11 +35,11 @@ Finally, the book's index allows readers to find very specific topics and the re
 
 _Italic_:: Indicates new terms, URLs, email addresses, filenames, and file extensions.
 
-+Constant width+:: Used for program listings, as well as within paragraphs to refer to program elements such as variable or function names, databases, data types, environment variables, statements, and keywords.
+`+Constant width+`:: Used for program listings, as well as within paragraphs to refer to program elements such as variable or function names, databases, data types, environment variables, statements, and keywords.
 
-**`Constant width bold`**:: Shows commands or other text that should be typed literally by the user.
+`**Constant width bold**`:: Shows commands or other text that should be typed literally by the user.
 
-_++Constant width italic++_:: Shows text that should be replaced with user-supplied values or values determined by context.
+`_++Constant width italic++_`:: Shows text that should be replaced with user-supplied values or values determined by context.
 
 
 [TIP]


### PR DESCRIPTION
Seems like constant width needed to use back ticks to show up well in preview mode.