### PR TITLE
Typos in Token contract

### DIFF
--- a/code/Solidity/Token.sol
+++ b/code/Solidity/Token.sol
@@ -1,6 +1,6 @@
-import "Faucet.sol"
+import "Faucet8.sol"
 
-contract Token is mortal {
+contract Token is Mortal {
     Faucet _faucet;
 
     constructor(address _f) {


### PR DESCRIPTION
The inherited contract, `Mortal` was incorrectly lowercased with `mortal`. After all revisions to the Faucet code, `Faucet8.sol` should be imported since it's the latest.