### PR TITLE
Function modifiers separated by spaces

### DIFF
--- a/07smart-contracts-solidity.asciidoc
+++ b/07smart-contracts-solidity.asciidoc
@@ -492,7 +492,7 @@ This function modifier, named +onlyOwner+, sets a condition on any function that
 
 You may have noticed that our function modifier has a peculiar syntactic "placeholder" in it, an underscore followed by a semicolon (+&#95;;+). This placeholder is replaced by the code of the function that is being modified. Essentially, the modifier is "wrapped around" the modified function, placing its code in the location identified by the underscore character.
 
-To apply a modifier, you add its name to the function declaration. More than one modifier can be applied to a function; they are applied in the sequence they are declared, as a comma-separated list.
+To apply a modifier, you add its name to the function declaration. More than one modifier can be applied to a function; they are applied in the sequence they are declared, as a space-separated list.
 
 Let's rewrite our +destroy+ function to use the +onlyOwner+ modifier:
 


### PR DESCRIPTION
Unless I misunderstood something, function modifiers are separated by spaces, and not commas?