### PR TITLE
Update raw_tx_demo.js for new lib versions

### DIFF
--- a/code/web3js/raw_tx/raw_tx_demo.js
+++ b/code/web3js/raw_tx/raw_tx_demo.js
@@ -12,7 +12,7 @@ const txData = {
   gasLimit: '0x30000',
   to: '0xb0920c523d582040f2bcb1bd7fb1c7c1ecebdb34',
   value: '0x00',
-  data: '',
+  data: '0x0',
   v: "0x1c", // Ethereum mainnet chainID
   r: 0,
   s: 0 


### PR DESCRIPTION
As of 30/07/2021, copy pasting this code directly didn't work for me. I was getting this exception: 

.../node_modules/ethereumjs-util/dist/bytes.js:80
```throw new Error("Cannot convert string to buffer. toBuffer only supports 0x-prefixed hex strings and this string was given: " + v);```

This commit barely sets the data field to 0x0 in order for the script to work. 

Test OS: macOS
Node version: v12.18.4
Ethereumjs-tx version: 2.1.2