### PR TITLE
Updated 02intro.asciidoc with an alternative faucet

### DIFF
--- a/02intro.asciidoc
+++ b/02intro.asciidoc
@@ -173,7 +173,7 @@ Your MetaMask wallet uses the same private key and Ethereum address on all the n
 
 ((("ether (generally)","testnet")))((("MetaMask","and testnet ether")))((("test ether","obtaining")))((("testnet","ether for")))((("wallets","testnet ether and")))Your first task is to get your wallet funded. You won't be doing that on the main network because real ether costs money and handling it requires a bit more experience. For now, you'll load your wallet with some testnet ether.
 
-((("Ropsten Test Network")))Switch MetaMask to the _Ropsten Test Network_. Click Deposit, then click Ropsten Test Faucet. MetaMask will open a new web page, as shown in <<metamask_ropsten_faucet>>.
+((("Ropsten Test Network")))Switch MetaMask to the _Ropsten Test Network_. Click Deposit, then click Ropsten Test Faucet. MetaMask will open a new web page, as shown in <<metamask_ropsten_faucet>>. Or, alternatively, if MetaMask faucet doesn't work; you can use https://faucet.dimensions.network/ to get yourself some test ether.
 
 [[metamask_ropsten_faucet]]
 .MetaMask Ropsten Test Faucet


### PR DESCRIPTION
MetaMask test faucet tends to glitch out a lot of times and not send any ether. An alternative faucet would be helpful.