### PR TITLE
Fix broken links in chapter 9

### DIFF
--- a/09smart-contracts-security.asciidoc
+++ b/09smart-contracts-security.asciidoc
@@ -850,7 +850,7 @@ Before discussing the actual issue, let's take a quick detour to
 understand how state variables actually get
 stored in contracts. State or storage variables (variables that
 persist over individual transactions) are placed into _slots_
-sequentially as they are introduced in the contract. (There are some complexities here; consult the http://bit.ly/2JslDWf[Solidity docs] for a more thorough understanding.)
+sequentially as they are introduced in the contract. (There are some complexities here; consult the https://docs.soliditylang.org/en/v0.8.11/internals/layout_in_storage.html[Solidity docs] for a more thorough understanding.)
 
 As an example, let’s look at the library contract. It has two state
 variables, `start` and `calculatedFibNumber`. The first variable,
@@ -2147,7 +2147,7 @@ future time, to make it look like a minute had elapsed) to make it
 appear that they were the last player to join for over a minute (even
 though this was not true in reality). More detail on this can be found in
 the
-http://bit.ly/2Q1AMA6[&#x201c;History
+https://applicature.com/blog/blockchain-technology/history-of-ethereum-security-vulnerabilities-hacks-and-their-fixes[&#x201c;History
 of Ethereum Security Vulnerabilities, Hacks and Their Fixes&#x201d; post] by Tanya pass:[<span class="keep-together">Bahrynovska</span>].(((range="endofrange", startref="ix_09smart-contracts-security-asciidoc42")))(((range="endofrange", startref="ix_09smart-contracts-security-asciidoc41")))
 
 === Constructors with Care
@@ -2216,7 +2216,7 @@ constructor’s name wasn’t changed, allowing any user to become the
 creator. Some interesting discussion related to this bug can be found
 on http://bit.ly/2P0TRWw[Bitcointalk]. Ultimately, it allowed users to fight for creator status to
 claim the fees from the pyramid scheme. More detail on this particular
-bug can be found in http://bit.ly/2Q1AMA6[&#x201c;History of Ethereum Security Vulnerabilities, Hacks and Their Fixes&#x201d;].
+bug can be found in https://applicature.com/blog/blockchain-technology/history-of-ethereum-security-vulnerabilities-hacks-and-their-fixes[&#x201c;History of Ethereum Security Vulnerabilities, Hacks and Their Fixes&#x201d;].
 
 === Uninitialized Storage Pointers
 
@@ -2226,7 +2226,7 @@ functions is highly recommended when developing contracts. This is
 because it is possible to produce vulnerable contracts by
 inappropriately initializing variables.
 
-To read more about storage and memory in the EVM, see the Solidity documentation on http://bit.ly/2OdUU0l[data location], http://bit.ly/2JslDWf[layout of state variables in storage], and http://bit.ly/2Dch2Hc[layout in memory].
+To read more about storage and memory in the EVM, see the Solidity documentation on http://bit.ly/2OdUU0l[data location], https://docs.soliditylang.org/en/v0.8.11/internals/layout_in_storage.html[layout of state variables in storage], and https://docs.soliditylang.org/en/v0.8.11/internals/layout_in_memory.html[layout in memory].
 
 [NOTE]
 ====


### PR DESCRIPTION
1. In the section about DELEGATECALL and  Uninitialized Storage Pointers, the links to Layout of state variables in storage and layout in memory were redirecting to no existent page in solidity docs.

2. The link to “History of
Ethereum Security Vulnerabilities, Hacks and Their Fixes” in  Block Timestamp Manipulation and Constructors sections  with Care were referencing a different subject on the blog