### PR TITLE
Update 09smart-contracts-security.asciidoc

### DIFF
--- a/09smart-contracts-security.asciidoc
+++ b/09smart-contracts-security.asciidoc
@@ -35,7 +35,7 @@ contracts to execute further code (through a fallback function),
 including calls back into themselves. Attacks of this kind were used in the
 infamous http://bit.ly/2DamSZT[DAO hack].
 
-For further reading on reentrancy attacks, see Gus Guimareas's http://bit.ly/2zaqSEY[blog post] on the subject and the http://bit.ly/2ERDMxV[Ethereum Smart Contract Best Practices].
+For further reading on reentrancy attacks, see Gus Guimareas's http://bit.ly/2zaqSEY[blog post] on the subject and the https://consensys.github.io/smart-contract-best-practices/attacks/[Ethereum Smart Contract Best Practices].
 
 [role="notoc"]
 ==== The Vulnerability


### PR DESCRIPTION
I changed the URL address of Ethereum best practices as the first one directed to page 404 not found.