### PR TITLE
Marking the sender address as 'payable'

### DIFF
--- a/code/Solidity/Faucet.sol
+++ b/code/Solidity/Faucet.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC-BY-SA-4.0
 
 // Version of Solidity compiler this program was written for
-pragma solidity 0.6.4;
+pragma solidity 0.8.7;
 
 // Our first contract is a faucet!
 contract Faucet {
@@ -14,6 +14,6 @@ contract Faucet {
         require(withdraw_amount <= 100000000000000000);
 
         // Send the amount to the address that requested it
-        msg.sender.transfer(withdraw_amount);
+        payable(msg.sender).transfer(withdraw_amount);
     }
 }


### PR DESCRIPTION
This is not compiling with latest version of solidity https://github.com/ethereumbook/ethereumbook/blob/develop/02intro.asciidoc#a-simple-contract-a-test-ether-faucet