### PR TITLE
fixed the broken link to Ethereum Smart Contract Best Practices

### DIFF
--- a/09smart-contracts-security.asciidoc
+++ b/09smart-contracts-security.asciidoc
@@ -35,7 +35,7 @@ contracts to execute further code (through a fallback function),
 including calls back into themselves. Attacks of this kind were used in the
 infamous http://bit.ly/2DamSZT[DAO hack].
 
-For further reading on reentrancy attacks, see Gus Guimareas's http://bit.ly/2zaqSEY[blog post] on the subject and the http://bit.ly/2ERDMxV[Ethereum Smart Contract Best Practices].
+For further reading on reentrancy attacks, see Gus Guimareas's http://bit.ly/2zaqSEY[blog post] on the subject and the https://consensys.github.io/smart-contract-best-practices/[Ethereum Smart Contract Best Practices].
 
 [role="notoc"]
 ==== The Vulnerability


### PR DESCRIPTION
Updated this link because a user pointed out the issue.

![issue](https://user-images.githubusercontent.com/85754527/180611071-9770bba1-4420-4667-9340-1b2d14b9471d.PNG)
