### PR TITLE
Update 01what-is.asciidoc => fix broken links on Further Reading

### DIFF
--- a/01what-is.asciidoc
+++ b/01what-is.asciidoc
@@ -152,7 +152,7 @@ https://github.com/chronaeon/beigepaper
 https://github.com/ethereum/devp2p/blob/master/rlpx.md
 
 * Ethereum Virtual Machine list of resources:
-https://eth.wiki/en/concepts/evm/ethereum-virtual-machine-(evm)-awesome-list
+https://ethereum.org/en/developers/docs/evm/
 
 * LevelDB database (used most often to store the local copy of the blockchain):
 https://github.com/google/leveldb

--- a/01what-is.asciidoc
+++ b/01what-is.asciidoc
@@ -158,10 +158,10 @@ https://eth.wiki/en/concepts/evm/ethereum-virtual-machine-(evm)-awesome-list
 https://github.com/google/leveldb
 
 * Merkle Patricia trees:
-https://eth.wiki/en/fundamentals/patricia-tree
+https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/#top
 
 * Ethash PoW algorithm:
-https://eth.wiki/en/concepts/ethash/ethash
+https://ethereum.org/en/developers/docs/consensus-mechanisms/pow/mining-algorithms/ethash/#top
 
 * Casper PoS v1 Implementation Guide:
 http://bit.ly/2DyPr3l


### PR DESCRIPTION
fix broken links :
- Merkle Patricia trees
- Ethash PoW algorithm

Note that  Ethereum Virtual Machine list of resources: https://eth.wiki/en/concepts/evm/ethereum-virtual-machine-(evm)-awesome-list is also broken but not sure what it was referring to?
Maybe this is an equivalent: https://ethereum.org/en/developers/docs/programming-languages/golang/#other-aggregated-lists