### PR TITLE
Chapter09/fix parity multisig 2nd hack code example

### DIFF
--- a/09smart-contracts-security.asciidoc
+++ b/09smart-contracts-security.asciidoc
@@ -948,7 +948,7 @@ context. There are a number of good explanations of this hack, such as
 http://bit.ly/2Dg7GtW[&#x201c;Parity Multisig Hacked. Again&#x201d;] and http://bit.ly/2Of06B9[&#x201c;An In-Depth Look at the Parity Multisig Bug&#x201d;].
 
 To add to these references, let’s explore the contracts that were
-exploited. The library and wallet contracts can be found http://bit.ly/2OgnXQC[on GitHub].
+exploited. The library and wallet contracts can be found http://bit.ly/3UcbCyX[on GitHub].
 
 The library contract is as follows:
 
@@ -958,13 +958,9 @@ contract WalletLibrary is WalletEvents {
 
   ...
 
-  // throw unless the contract is not yet initialized.
-  modifier only_uninitialized { if (m_numOwners > 0) throw; _; }
-
   // constructor - just pass on the owner array to multiowned and
   // the limit to daylimit
-  function initWallet(address[] _owners, uint _required, uint _daylimit)
-      only_uninitialized {
+  function initWallet(address[] _owners, uint _required, uint _daylimit) {
     initDaylimit(_daylimit);
     initMultiowned(_owners, _required);
   }

--- a/github_contrib.asciidoc
+++ b/github_contrib.asciidoc
@@ -143,6 +143,7 @@ Following is an alphabetically sorted list of all the GitHub contributors, inclu
 * Paulo Trezentos (paulotrezentos)
 * Pet3rpan (pet3r-pan)
 * Peter Kacherginsky (iphelix)
+* Peter Slaný (peterslany)
 * Pierre-Jean Subervie (pjsub)
 * Pong Cheecharern (Pongch)
 * Qiao Wang (qiaowang26)


### PR DESCRIPTION
Fixing smart contract example for chapter 9. Current version contains [patched smart contracts version](https://github.com/openethereum/parity-ethereum/commit/b640df8fbb964da7538eef268dffc125b081a82f#diff-8ea4aa7c2ba715c683bc764337f51585) and therefore does not contain the vulnerability that is described in the text. I updated the snippet to use the exploited version of smart contract and changed the URL to reference to link to this version too.