### PR TITLE
Update testnets (e.g. Ropsten to Sepolia)

### DIFF
--- a/02intro.asciidoc
+++ b/02intro.asciidoc
@@ -153,7 +153,7 @@ Congratulations! You have set up your first Ethereum wallet.(((range="endofrange
 
 Main Ethereum Network:: The main public Ethereum blockchain. Real ETH, real value, and real consequences.
 
-Ropsten Test Network:: Ethereum public test blockchain and network. ETH on this network has no value.
+Sepolia Test Network:: Ethereum public test blockchain and network. ETH on this network has no value.
 
 Kovan Test Network:: Ethereum public test blockchain and network using the Aura consensus protocol with proof of authority (federated signing). ETH on this network has no value. The Kovan test network is supported by Parity only. Other Ethereum clients use the Clique consensus protocol, which was proposed later, for proof of authority&#x2013;based verification.
 
@@ -165,7 +165,7 @@ Custom RPC:: Allows you to connect MetaMask to any node with a Geth-compatible R
 
 [NOTE]
 ====
-Your MetaMask wallet uses the same private key and Ethereum address on all the networks it connects to. However, your Ethereum address balance on each Ethereum network will be different. Your keys may control ether and contracts on Ropsten, for example, but not on the main network.
+Your MetaMask wallet uses the same private key and Ethereum address on all the networks it connects to. However, your Ethereum address balance on each Ethereum network will be different. Your keys may control ether and contracts on Sepolia, for example, but not on the main network.
 ====
 
 [[getting_test_eth]]
@@ -173,11 +173,11 @@ Your MetaMask wallet uses the same private key and Ethereum address on all the n
 
 ((("ether (generally)","testnet")))((("MetaMask","and testnet ether")))((("test ether","obtaining")))((("testnet","ether for")))((("wallets","testnet ether and")))Your first task is to get your wallet funded. You won't be doing that on the main network because real ether costs money and handling it requires a bit more experience. For now, you'll load your wallet with some testnet ether.
 
-((("Ropsten Test Network")))Switch MetaMask to the _Ropsten Test Network_. Click Deposit, then click Ropsten Test Faucet. MetaMask will open a new web page, as shown in <<metamask_ropsten_faucet>>.
+((("Sepolia Test Network")))Switch MetaMask to the _Sepolia Test Network_. Click Deposit, then click Sepolia Test Faucet. MetaMask will open a new web page, as shown in <<metamask_sepolia_faucet>>.
 
-[[metamask_ropsten_faucet]]
-.MetaMask Ropsten Test Faucet
-image::images/metamask_ropsten_faucet.png["MetaMask Ropsten Test Faucet"]
+[[metamask_sepolia_faucet]]
+.MetaMask Sepolia Test Faucet
+image::images/metamask_sepolia_faucet.png["MetaMask Sepolia Test Faucet"]
 
 You may notice that the web page already contains your MetaMask wallet's Ethereum address. MetaMask integrates Ethereum-enabled web pages with your MetaMask wallet and can "see" Ethereum addresses on the web page, allowing you, for example, to send a payment to an online shop displaying an Ethereum address. MetaMask can also populate the web page with your own wallet's address as a recipient address if the web page requests it. In this page, the faucet application is asking MetaMask for a wallet address to send test ether to.
 
@@ -188,20 +188,20 @@ Click the green "request 1 ether from faucet" button. You will see a transaction
 0x7c7ad5aaea6474adccf6f5c5d6abed11b70a350fbc6f9590109e099568090c57
 ----
 
-In a few seconds, the new transaction will be mined by the Ropsten miners and your MetaMask wallet will show a balance of 1 ETH. Click on the transaction ID and your browser will take you to a _block explorer_, which is a website that allows you to visualize and explore blocks, addresses, and transactions. MetaMask uses the https://etherscan.io/[Etherscan block explorer], one of the more popular Ethereum block explorers. The transaction containing the payment from the Ropsten Test Faucet is shown in <<ropsten_block_explorer>>.
+In a few seconds, the new transaction will be mined by the Sepolia miners and your MetaMask wallet will show a balance of 1 ETH. Click on the transaction ID and your browser will take you to a _block explorer_, which is a website that allows you to visualize and explore blocks, addresses, and transactions. MetaMask uses the https://etherscan.io/[Etherscan block explorer], one of the more popular Ethereum block explorers. The transaction containing the payment from the Sepolia Test Faucet is shown in <<sepolia_block_explorer>>.
 
-[[ropsten_block_explorer]]
-.Etherscan Ropsten block explorer
-image::images/ropsten_block_explorer.png["Etherscan Ropsten Block Explorer"]
+[[sepolia_block_explorer]]
+.Etherscan Sepolia block explorer
+image::images/sepolia_block_explorer.png["Etherscan Sepolia Block Explorer"]
 
-The transaction has been recorded on the Ropsten blockchain and can be viewed at any time by anyone, simply by searching for the transaction ID, or http://bit.ly/2Q860Wk[visiting the link].
+The transaction has been recorded on the Sepolia blockchain and can be viewed at any time by anyone, simply by searching for the transaction ID, or http://bit.ly/2Q860Wk[visiting the link].
 
-Try visiting that link, or entering the transaction hash into the _ropsten.etherscan.io_ website, to see it for yourself.
+Try visiting that link, or entering the transaction hash into the _sepolia.etherscan.io_ website, to see it for yourself.
 
 [[sending_eth_MetaMask]]
 ==== Sending Ether from MetaMask
 
-((("MetaMask","sending ether from", id="ix_02intro-asciidoc6", range="startofrange")))((("test ether","sending", id="ix_02intro-asciidoc7", range="startofrange")))Once you've received your first test ether from the Ropsten Test Faucet, you can experiment with sending ether by trying to send some back to the faucet. As you can see on the Ropsten Test Faucet page, there is an option to "donate" 1 ETH to the faucet. This option is available so that once you're done testing, you can return the remainder of your test ether, so that someone else can use it next. Even though test ether has no value, some people hoard it, making it difficult for everyone else to use the test networks. Hoarding test ether is frowned upon!
+((("MetaMask","sending ether from", id="ix_02intro-asciidoc6", range="startofrange")))((("test ether","sending", id="ix_02intro-asciidoc7", range="startofrange")))Once you've received your first test ether from the Sepolia Test Faucet, you can experiment with sending ether by trying to send some back to the faucet. As you can see on the Sepolia Test Faucet page, there is an option to "donate" 1 ETH to the faucet. This option is available so that once you're done testing, you can return the remainder of your test ether, so that someone else can use it next. Even though test ether has no value, some people hoard it, making it difficult for everyone else to use the test networks. Hoarding test ether is frowned upon!
 
 Fortunately, we are not test ether hoarders. Click the orange "1 ether" button to tell MetaMask to create a transaction paying the faucet 1 ether. MetaMask will prepare a transaction and pop up a window with the confirmation, as shown in <<send_to_faucet>>.
 
@@ -230,7 +230,7 @@ Once you have a balance of 2 ETH, you can try again. This time, when you click t
 [[explore_tx_history]]
 ==== Exploring the Transaction History of an Address
 
-((("addresses","exploring transaction history of", id="ix_02intro-asciidoc8", range="startofrange")))((("MetaMask","exploring transaction history of an address with", id="ix_02intro-asciidoc9", range="startofrange")))By now you have become an expert in using MetaMask to send and receive test ether. Your wallet has received at least two payments and sent at least one. You can view all these transactions using the _ropsten.etherscan.io_ block explorer. You can either copy your wallet address and paste it into the block explorer's search box, or have MetaMask open the page for you. Next to your account icon in MetaMask, you will see a button showing three dots. Click on it to show a menu of account-related options (see <<metamask_account_context_menu>>).
+((("addresses","exploring transaction history of", id="ix_02intro-asciidoc8", range="startofrange")))((("MetaMask","exploring transaction history of an address with", id="ix_02intro-asciidoc9", range="startofrange")))By now you have become an expert in using MetaMask to send and receive test ether. Your wallet has received at least two payments and sent at least one. You can view all these transactions using the _sepolia.etherscan.io_ block explorer. You can either copy your wallet address and paste it into the block explorer's search box, or have MetaMask open the page for you. Next to your account icon in MetaMask, you will see a button showing three dots. Click on it to show a menu of account-related options (see <<metamask_account_context_menu>>).
 
 [[metamask_account_context_menu]]
 .MetaMask account context menu
@@ -242,9 +242,9 @@ Select "View account on Etherscan" to open a web page in the block explorer show
 .Address transaction history on Etherscan
 image::images/block_explorer_account_history.png["Address Transaction History on Etherscan"]
 
-Here you can see the entire transaction history of your Ethereum address. It shows all the transactions recorded on the Ropsten blockchain where your address is the sender or recipient. Click on a few of these transactions to see more details.
+Here you can see the entire transaction history of your Ethereum address. It shows all the transactions recorded on the Sepolia blockchain where your address is the sender or recipient. Click on a few of these transactions to see more details.
 
-You can explore the transaction history of any address. Take a look at the transaction history of the Ropsten Test Faucet address (hint: it is the "sender" address listed in the oldest payment to your address). You can see all the test ether sent from the faucet to you and to other addresses. Every transaction you see can lead you to more addresses and more transactions. Before long you will be lost in the maze of interconnected data. Public blockchains contain an enormous wealth of information, all of which can be explored programmatically, as we will see in future examples(((range="endofrange", startref="ix_02intro-asciidoc9")))(((range="endofrange", startref="ix_02intro-asciidoc8"))).(((range="endofrange", startref="ix_02intro-asciidoc3")))(((range="endofrange", startref="ix_02intro-asciidoc2")))
+You can explore the transaction history of any address. Take a look at the transaction history of the Sepolia Test Faucet address (hint: it is the "sender" address listed in the oldest payment to your address). You can see all the test ether sent from the faucet to you and to other addresses. Every transaction you see can lead you to more addresses and more transactions. Before long you will be lost in the maze of interconnected data. Public blockchains contain an enormous wealth of information, all of which can be explored programmatically, as we will see in future examples(((range="endofrange", startref="ix_02intro-asciidoc9")))(((range="endofrange", startref="ix_02intro-asciidoc8"))).(((range="endofrange", startref="ix_02intro-asciidoc3")))(((range="endofrange", startref="ix_02intro-asciidoc2")))
 
 [[intro_world_computer]]
 === Introducing the World Computer
@@ -262,14 +262,14 @@ Contracts have addresses, just like EOAs. Contracts can also send and receive et
 
 Note that because a contract account does not have a private key, it cannot _initiate_ a transaction. Only EOAs can initiate transactions, but contracts can _react_ to transactions by calling other contracts, building complex execution paths. One typical use of this is an EOA sending a request transaction to a multisignature smart contract wallet to send some ETH on to another address. A typical DApp programming pattern is to have Contract A calling Contract B in order to maintain a shared state across users of Contract A.
 
-In the next few sections, we will write our first contract. You will then learn how to create, fund, and use that contract with your MetaMask wallet and test ether on the Ropsten test network.
+In the next few sections, we will write our first contract. You will then learn how to create, fund, and use that contract with your MetaMask wallet and test ether on the Sepolia test network.
 
 [[simple_contract_example]]
 === A Simple Contract: A Test Ether Faucet
 
 ((("contract accounts","creating", seealso="Faucet.sol contract", id="ix_02intro-asciidoc10", range="startofrange")))((("Faucet.sol contract (test example)","creating", id="ix_02intro-asciidoc11", range="startofrange")))Ethereum has many different high-level languages, all of which can be used to write a contract and produce EVM bytecode. You can read about many of the most prominent and interesting ones in <<high_level_languages>>. One high-level language is by far the dominant choice for smart contract programming: Solidity. ((("Wood, Dr. Gavin","and Solidity")))Solidity was created by Dr. Gavin Wood, the coauthor of this book, and has become the most widely used language in Ethereum (and beyond). We'll use Solidity to write our first contract.
 
-((("Solidity","faucet.sol and")))For our first example (<<solidity_faucet_example>>), we will write a contract that controls a _faucet_. You've already used a faucet to get test ether on the Ropsten test network. A faucet is a relatively simple thing: it gives out ether to any address that asks, and can be refilled periodically. You can implement a faucet as a wallet controlled by a human or a web server.
+((("Solidity","faucet.sol and")))For our first example (<<solidity_faucet_example>>), we will write a contract that controls a _faucet_. You've already used a faucet to get test ether on the Sepolia test network. A faucet is a relatively simple thing: it gives out ether to any address that asks, and can be refilled periodically. You can implement a faucet as a wallet controlled by a human or a web server.
 
 [[solidity_faucet_example]]
 .Faucet.sol: A Solidity contract implementing a faucet
@@ -402,11 +402,11 @@ Aren't you glad you are using a high-level language like Solidity instead of pro
 [[create_contract]]
 === Creating the Contract on the Blockchain
 
-((("blockchain","creating contract on", id="ix_02intro-asciidoc14", range="startofrange")))((("Faucet.sol contract (test example)","on the blockchain", id="ix_02intro-asciidoc15", range="startofrange")))So, we have a contract. We've compiled it into bytecode. Now, we need to "register" the contract on the Ethereum blockchain. We will be using the Ropsten testnet to test our contract, so that's the blockchain we want to submit it to.
+((("blockchain","creating contract on", id="ix_02intro-asciidoc14", range="startofrange")))((("Faucet.sol contract (test example)","on the blockchain", id="ix_02intro-asciidoc15", range="startofrange")))So, we have a contract. We've compiled it into bytecode. Now, we need to "register" the contract on the Ethereum blockchain. We will be using the Sepolia testnet to test our contract, so that's the blockchain we want to submit it to.
 
 ((("zero address","contract registration")))Registering a contract on the blockchain involves creating a special transaction whose destination is the address +0x0000000000000000000000000000000000000000+, also known as the _zero address_. The zero address is a special address that tells the Ethereum blockchain that you want to register a contract. Fortunately, the Remix IDE will handle all of that for you and send the transaction to MetaMask.
 
-((("Remix IDE", id="ix_02intro-asciidoc16", range="startofrange")))First, switch to the Run tab and select Injected Web3 in the Environment drop-down selection box. This connects the Remix IDE to the MetaMask wallet, and through MetaMask to the Ropsten test network. Once you do that, you can see Ropsten under Environment. Also, in the Account selection box it shows the address of your wallet (see <<remix_run>>).
+((("Remix IDE", id="ix_02intro-asciidoc16", range="startofrange")))First, switch to the Run tab and select Injected Web3 in the Environment drop-down selection box. This connects the Remix IDE to the MetaMask wallet, and through MetaMask to the Sepolia test network. Once you do that, you can see Sepolia under Environment. Also, in the Account selection box it shows the address of your wallet (see <<remix_run>>).
 
 [[remix_run]]
 .Remix IDE Run tab, with Injected Web3 environment selected
@@ -420,7 +420,7 @@ Remix will construct the special "creation" transaction and MetaMask will ask yo
 .MetaMask showing the contract creation transaction
 image::images/remix_metamask_create.png["MetaMask showing the contract creation transaction"]
 
-Now you have to wait. It will take about 15 to 30 seconds for the contract to be mined on Ropsten. Remix won't appear to be doing much, but be patient.
+Now you have to wait. It will take about 15 to 30 seconds for the contract to be mined on Sepolia. Remix won't appear to be doing much, but be patient.
 
 Once the contract is created, it appears at the bottom of the Run tab (see <<remix_contract_interact>>).
 
@@ -438,13 +438,13 @@ Notice that the +Faucet+ contract now has an address of its own: Remix shows it 
 [[view_contract_address]]
 ==== Viewing the Contract Address in a Block Explorer
 
-((("Faucet.sol contract (test example)","viewing contract address in a block explorer")))We now have a contract recorded on the blockchain, and we can see it has an Ethereum address. Let's check it out in the _ropsten.etherscan.io_ block explorer and see what a contract looks like. In the Remix IDE, copy the address of the contract by clicking the clipboard icon next to its name (see <<remix_contract_address>>).
+((("Faucet.sol contract (test example)","viewing contract address in a block explorer")))We now have a contract recorded on the blockchain, and we can see it has an Ethereum address. Let's check it out in the _sepolia.etherscan.io_ block explorer and see what a contract looks like. In the Remix IDE, copy the address of the contract by clicking the clipboard icon next to its name (see <<remix_contract_address>>).
 
 [[remix_contract_address]]
 .Copy the contract address from Remix
 image::images/remix_contract_address.png["Copy the contract address from Remix"]
 
-Keep Remix open; we'll come back to it again later. Now, navigate your browser to _ropsten.etherscan.io_ and paste the address into the search box. You should see the contract's Ethereum address history, as shown in <<etherscan_contract_address>>.(((range="endofrange", startref="ix_02intro-asciidoc17")))
+Keep Remix open; we'll come back to it again later. Now, navigate your browser to _sepolia.etherscan.io_ and paste the address into the search box. You should see the contract's Ethereum address history, as shown in <<etherscan_contract_address>>.(((range="endofrange", startref="ix_02intro-asciidoc17")))
 
 [[etherscan_contract_address]]
 .View the Faucet contract address in the Etherscan block explorer
@@ -536,9 +536,9 @@ image::images/etherscan_withdrawal_internal.png["Etherscan shows the internal tr
 [[intro_conclusion]]
 === Conclusions
 
-In this chapter, you set up a wallet using MetaMask and funded it using a faucet on the Ropsten test network. You received ether into your wallet's Ethereum address, then you sent ether to the faucet's Ethereum address.
+In this chapter, you set up a wallet using MetaMask and funded it using a faucet on the Sepolia test network. You received ether into your wallet's Ethereum address, then you sent ether to the faucet's Ethereum address.
 
-Next, you wrote a faucet contract in Solidity. You used the Remix IDE to compile the contract into EVM bytecode, then used Remix to form a transaction and created the +Faucet+ contract on the Ropsten blockchain. Once created, the +Faucet+ contract had an Ethereum address, and you sent it some ether. Finally, you constructed a transaction to call the +withdraw+ function and successfully asked for 0.1 ether. The contract checked the request and sent you 0.1 ether with an internal transaction.
+Next, you wrote a faucet contract in Solidity. You used the Remix IDE to compile the contract into EVM bytecode, then used Remix to form a transaction and created the +Faucet+ contract on the Sepolia blockchain. Once created, the +Faucet+ contract had an Ethereum address, and you sent it some ether. Finally, you constructed a transaction to call the +withdraw+ function and successfully asked for 0.1 ether. The contract checked the request and sent you 0.1 ether with an internal transaction.
 
 It may not seem like much, but you've just successfully interacted with software that controls money on a decentralized world computer.
 


### PR DESCRIPTION
- [x] Find/replace Ropsten > Sepolia
- [ ] Update Ropsten screenshots
- [ ] Update Kovan testnet
- [ ] Update Rinkeby testnet

Fixes #1033 (eventually once the TLS cert is updated)