### PR TITLE
Update 06transactions.asciidoc chainIds

### DIFF
--- a/06transactions.asciidoc
+++ b/06transactions.asciidoc
@@ -689,6 +689,8 @@ The chain identifier field takes a value according to the network the transactio
 | Morden (obsolete), Expanse | 2
 | Ropsten | 3
 | Rinkeby | 4
+| Goerli | 5
+| Sepolia | 11155111
 | Rootstock mainnet | 30
 | Rootstock testnet | 31
 | Kovan | 42


### PR DESCRIPTION
This commit will add the Sepolia and Goerli testnet chainIds to the list of networks and chain ids