### PR TITLE
Update 13evm.asciidoc

### DIFF
--- a/13evm.asciidoc
+++ b/13evm.asciidoc
@@ -171,8 +171,8 @@ CODECOPY       //Copy the code running in the current environment to
                //memory
 GASPRICE       //Get the gas price specified by the originating
                //transaction
-EXTCODESIZE    //Get the size of any account's code
-EXTCODECOPY    //Copy any account's code to memory
+EXTCODESIZE    //Get the size of an account's code
+EXTCODECOPY    //Copy an account's code to memory
 RETURNDATASIZE //Get the size of the output data from the previous call
                //in the current environment
 RETURNDATACOPY //Copy data output from the previous call to memory


### PR DESCRIPTION
Correct a logical error in the description of the `EXTCODESIZE` and `EXTCODECOPY` opcodes: they work on a specific account (given to them as input), and not just "any" account.