### PR TITLE
Update raw_tx_demo.js

### DIFF
--- a/code/web3js/raw_tx/raw_tx_demo.js
+++ b/code/web3js/raw_tx/raw_tx_demo.js
@@ -12,7 +12,7 @@ const txData = {
   gasLimit: '0x30000',
   to: '0xb0920c523d582040f2bcb1bd7fb1c7c1ecebdb34',
   value: '0x00',
-  data: '',
+  data: '0x',
   v: "0x1c", // Ethereum mainnet chainID
   r: 0,
   s: 0 


### PR DESCRIPTION
Added '0x' in data: (line 15)

Error message: throw new Error("Cannot convert string to buffer. toBuffer only supports 0x-prefixed hex strings and this string was given: " + v);