### PR TITLE
Fix typos in documentation and comments

### DIFF
--- a/code/auction_dapp/DEV_README.md
+++ b/code/auction_dapp/DEV_README.md
@@ -23,7 +23,7 @@ Edit `truffle.js` :
 $ truffle init #initialize truffle project
 $ truffle console
 $ truffle deploy
-$ truffle migrate --reset --compile-all #redeploy the smat contracts
+$ truffle migrate --reset --compile-all #redeploy the smart contracts
 
 ```
 

--- a/code/auction_dapp/README.md
+++ b/code/auction_dapp/README.md
@@ -26,7 +26,7 @@ Auction repository MUST act as an auction house which does the following:
 - Holds asset/token/deed that is to be auctioned(ERC721 Ownership by smart contract)
 - Allows users bid on auctions
 - Keeps track of auctions/bids/ownership
-- Transfers ownership of asset/token/deed to winder
+- Transfers ownership of asset/token/deed to winner
 - Transfers Funds to auction creator if auction is ended and there is at least one winner
 - Cancels auction and deal with refunds
 - UI to interact with the above functionality
@@ -54,7 +54,7 @@ Creating the auction is a simple process of entering auction details such as nam
 Anyone can bid on an auction except the owner of the auction. Biding means that previous bidders are refunded and new bid is placed. Bid requirements are as follow:
 1. Auction not expired
 2. Bidder is not auction owner
-3. Bid amount is greator than current bid or starting price(if no bid)
+3. Bid amount is greater than current bid or starting price(if no bid)
 
 #### 5. Refunds
 


### PR DESCRIPTION

These changes improve the documentation quality by fixing several typos:
1. "smat" → "smart": Corrects the technical term "smart contracts"
2. "winder" → "winner": Fixes incorrect spelling of the auction winner
3. "greator" → "greater": Corrects the spelling of the comparative adjective

These corrections make the documentation more professional and easier to understand for developers using the auction dApp.

