### PR TITLE
Correcting the date of the Ethereum Merge to September 2022

### DIFF
--- a/src/chapter_1.md
+++ b/src/chapter_1.md
@@ -16,7 +16,7 @@ Ethereum’s purpose is not primarily to be a digital currency payment network. 
 
 Unlike Bitcoin, which has a very limited scripting language, Ethereum is designed to be a general-purpose, programmable blockchain that runs a virtual machine capable of executing code of arbitrary and unbounded complexity. Where Bitcoin’s Script language is intentionally constrained to simple true/false evaluation of spending conditions, Ethereum’s language is *Turing complete*, meaning that Ethereum can function as a general-purpose computer.
 
-In March 2023, Ethereum further distinguished itself from Bitcoin with The Merge upgrade, transitioning its consensus model from proof of work (PoW) to proof of stake (PoS). This important change not only underlines Ethereum’s commitment to reducing its environmental impact—aligning with its innovative vision—but also enhances its scalability and security features.
+In September 2022, Ethereum further distinguished itself from Bitcoin with The Merge upgrade, transitioning its consensus model from proof of work (PoW) to proof of stake (PoS). This important change not only underlines Ethereum’s commitment to reducing its environmental impact—aligning with its innovative vision—but also enhances its scalability and security features.
 
 ## Components of a Blockchain
 


### PR DESCRIPTION
Historically, the Ethereum Merge took place in September 2022