### PR TITLE
Inaccurate description of bilinear pairing in KZG

### DIFF
--- a/src/chapter_4.md
+++ b/src/chapter_4.md
@@ -897,7 +897,7 @@ If we take the verifier equation and write it to the pairing group, basically co
 [q(s)(s – z)]ₜ = [p(s) – y]ₜ
 ```
 
-where `T` is a different elliptic curve.
+where `T` is a a multiplicative subgroup of a finite field extension.
 
 You can just see that this equation is the exact same equation we calculated before:
 


### PR DESCRIPTION
T should be described as the target group of the bilinear pairing, not as an elliptic curve.

In BLS12-381/KZG, G_1 and G_2 are elliptic-curve groups; G_T lives in a finite field extension.