### PR TITLE
Fix EXTCODESIZE and EXTCODECOPY opcode descriptions

### DIFF
--- a/src/chapter_14.md
+++ b/src/chapter_14.md
@@ -189,8 +189,8 @@ CODECOPY       //Copy the code running in the current environment to
                //memory
 GASPRICE       //Get the gas price specified by the originating
                //transaction
-EXTCODESIZE    //Get the size of any account's code
-EXTCODECOPY    //Copy any account's code to memory
+EXTCODESIZE    //Get the size of an account's code
+EXTCODECOPY    //Copy an account's code to memory
 RETURNDATASIZE //Get the size of the output data from the previous call
                //in the current environment
 RETURNDATACOPY //Copy data output from the previous call to memory


### PR DESCRIPTION
Correct a logical error in the description of the `EXTCODESIZE` and `EXTCODECOPY` opcodes: they work on a specific account (given to them as input via the stack), not just "any" account.

This is a resubmission of #1203 against the second edition, as requested by @alessandromazza98 in https://github.com/ethereumbook/ethereumbook/pull/1203#issuecomment-3589528805.