### PR TITLE
Fix EIP-1559 raw transaction example in Chapter 6

### DIFF
--- a/src/chapter_6.md
+++ b/src/chapter_6.md
@@ -879,7 +879,8 @@ const wallet = new ethers.Wallet(privateKey, provider);
 const recipient = "0xRECIPENT_ADDRESS"; // example address
 
 async function createAndSendRawEip1559Tx() {
-  const chainId = await provider.getChainId(); // This is a RPC call
+  const network = await provider.getNetwork(); // This is a RPC call
+  const chainId = network.chainId;
   const nonce = await provider.getTransactionCount(wallet.address); // This is a RPC call
 
   // Example parameters — adjust as needed (or use provider.estimateGas + getFeeData)
@@ -892,13 +893,13 @@ async function createAndSendRawEip1559Tx() {
 
   // Unsigned fields in strict order for Transaction Type 2
   const unsignedFields = [
-    ethers.toBeHex(chainId),              // chainId
-    ethers.toBeHex(nonce),                // nonce
-    ethers.toBeHex(gasLimit),             // gasLimit
-    ethers.toBeHex(maxPriorityFeePerGas), // maxPriorityFeePerGas
-    ethers.toBeHex(maxFeePerGas),         // maxFeePerGas
+    chainId,                              // chainId
+    nonce,                                // nonce
+    maxPriorityFeePerGas,                 // maxPriorityFeePerGas
+    maxFeePerGas,                         // maxFeePerGas
+    gasLimit,                             // gasLimit
     recipient,                            // to
-    ethers.toBeHex(value),                // value
+    value,                                // value
     data,                                 // data
     accessList                            // accessList
   ];
@@ -920,9 +921,9 @@ async function createAndSendRawEip1559Tx() {
   // For typed transactions we use yParity (0 or 1) instead of legacy v
   const signedFields = [
     ...unsignedFields,
-    sig.v - 27, // yParity (0 or 1)
-    sig.r,
-    sig.s
+    signature.v - 27, // yParity (0 or 1)
+    signature.r,
+    signature.s
   ];
 
   const encodedSigned = RLP.encode(signedFields);


### PR DESCRIPTION
Fixes #1292

Fixed bugs in the "Low-Level Manual Construction of an EIP-1559 Raw Transaction" example:

- Wrong field order: `gasLimit`, `maxPriorityFeePerGas`, and `maxFeePerGas` were in the wrong positions. Corrected to match the [EIP-1559 spec](https://eips.ethereum.org/EIPS/eip-1559): `chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, ...`
- Non-canonical RLP encoding: `ethers.toBeHex(0)` returns `"0x00"`, which has a leading zero byte. RLP canonical encoding requires zero to be empty bytes, causing nodes to reject the transaction. Removed `toBeHex` wrapping and pass raw values directly to `RLP.encode`, which handles canonical encoding internally
- Undefined variable `sig`: signing result was assigned to `signature` but referenced as `sig`
- Old ethers API usage — `provider.getChainId()` doesn't exist in ethers v6. Chain ID is now derived from `provider.getNetwork()`  ([reference](https://github.com/ethers-io/ethers.js/discussions/4621))
