### PR TITLE
Fix Chapter 9: Correct balance deduction logic Example 9-1. 

### DIFF
--- a/src/chapter_9.md
+++ b/src/chapter_9.md
@@ -66,7 +66,7 @@ Reentrancy can be tricky to grasp without a practical example. Take a look at th
 15        }
 16      (bool res, ) = address(msg.sender).call{value: _amt}("");
 17        require(res, "Transfer failed");
-18      balances[msg.sender] = 0;
+18      balances[msg.sender] -= _amt;
 19        lastWithdrawTime[msg.sender] = block.timestamp;
 20    }
 21 }


### PR DESCRIPTION
The EtherStore example in the reentrancy section contains a secondary 
logic bug unrelated to the reentrancy vulnerability being demonstrated.

When a user's balance exceeds withdrawalLimit (1 ETH), the function 
correctly limits _amt to 1 ETH, but then resets the entire balance to 
zero instead of deducting only the withdrawn amount.

This could mislead readers into applying the same pattern in production,
silently burning user funds without any attacker involvement.

Fix: balances[msg.sender] -= _amt;