### PR TITLE
Share calculation should be before asset transfer

### DIFF
--- a/src/chapter_9.md
+++ b/src/chapter_9.md
@@ -734,8 +734,8 @@ We will now see a precision-loss vulnerability commonly exploited in the wild, u
 10        return _asset.balanceOf(address(this));
 11    }
 12    function deposit(address receiver, uint256 assets) public {
-13        SafeERC20.safeTransferFrom(_asset, msg.sender, address(this), assets);
-14        uint256 shares = _convertToShares(assets, Math.Rounding.Down);
+13        uint256 shares = _convertToShares(assets, Math.Rounding.Down);
+14        SafeERC20.safeTransferFrom(_asset, msg.sender, address(this), assets);
 15        _mint(receiver, shares);
 16        emit Deposit(msg.sender, receiver, assets, shares);
 17    }


### PR DESCRIPTION
The amount of shares is calculated using the _convertToShares function which depends on total assets. The way _convertToShares is implemented, it needs the total assets before the deposit happens. So we must do the share calculation before calling the safeTransferFrom function which will increase the total assets of the contract. For reference: https://github.com/transmissions11/solmate/blob/main/src/tokens/ERC4626.sol

Closes #1304