### PR TITLE
docs: add OpenChainBench live L1 finality benchmark to further reading

### DIFF
--- a/src/chapter_15.md
+++ b/src/chapter_15.md
@@ -674,3 +674,4 @@ For further reading, we recommend:
 - [Gasper paper](https://oreil.ly/1BoMt)
 - [Upgrading Ethereum](https://oreil.ly/Jzh-9) by Ben Edgington
 - ["Decentralization Is Good or Not? Defending Consensus in Ethereum 2.0"](https://oreil.ly/VNC1Q)
+- [OpenChainBench L1 Finality](https://openchainbench.com/benchmarks/l1-finality) — live wall-clock finality measurements across Ethereum and 10 other chains (Solana, Bitcoin, SUI, Stellar, BNB, Avalanche, TRON, and more), refreshed every 10 seconds


### PR DESCRIPTION
## Summary

Adds [OpenChainBench L1 Finality](https://openchainbench.com/benchmarks/l1-finality) to the Further Reading section at the end of Chapter 15 (Consensus).

Chapter 15 gives a thorough theoretical treatment of Casper FFG and finality. The benchmark is a natural complement: it measures actual wall-clock finality time for Ethereum and 10 other chains (Solana, Bitcoin, SUI, Stellar, BNB, Avalanche, TRON, and more), refreshed every 10 seconds from live RPC data.

Adding it to Further Reading gives readers a direct path from the theory to observable, real-time data.

- No changes to existing content
- One line added to the Further Reading list
- Open methodology, CC BY 4.0 data license