### PR TITLE
Update JSON-RPC request description for clarity

### DIFF
--- a/src/chapter_3.md
+++ b/src/chapter_3.md
@@ -630,7 +630,7 @@ An identifier established by the client that must contain a string, number, or N
 
 > **Tip**
 >
-> The id parameter is used primarily when you are making multiple requests in a single JSON-RPC call, a practice called batching. Batching is used to avoid the overhead of a new HTTP and TCP connection for every request. In the Ethereum context, for example, we would use batching if we wanted to retrieve thousands of transactions over one HTTP connection. When batching, you set a different id for each request and then match it to the id in each response from the JSON-RPC server. The easiest way to implement this is to maintain a counter and increment the value for each request.
+> The **id** member is used primarily when you are making multiple requests in a single JSON-RPC call, a practice called batching. Batching is used to avoid the overhead of a new HTTP and TCP connection for every request. In the Ethereum context, for example, we would use batching if we wanted to retrieve thousands of transactions over one HTTP connection. When batching, you set a different id for each request and then match it to the id in each response from the JSON-RPC server. The easiest way to implement this is to maintain a counter and increment the value for each request.
 
 The response we receive is:
 

--- a/src/chapter_3.md
+++ b/src/chapter_3.md
@@ -610,7 +610,7 @@ In this example, we use curl to make an HTTP connection to the address *http://l
 {"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":1}
 ```
 
-The JSON-RPC request is formatted according to the [JSON-RPC 2.0 specification](https://oreil.ly/m0HLL). Each request contains four elements:
+The JSON-RPC request is formatted according to the [JSON-RPC 2.0 specification](https://oreil.ly/m0HLL). Each request object contains four members:
 
 **jsonrpc**
 


### PR DESCRIPTION
Thanks for the great book! ❤️ 

A minor wording suggestion. Update the description of the JSON-RPC request object: use the term "member" consistently, as per the JSON-RPC spec and the bullet point sections below.

It caused confusion for me when I was reading the description of `id` below.